### PR TITLE
feat(form-engine): registry integration fixes (step 03)

### DIFF
--- a/packages/form-engine/src/components/fields/types.ts
+++ b/packages/form-engine/src/components/fields/types.ts
@@ -7,7 +7,7 @@ export interface FieldError {
 
 export interface FieldProps<TFieldValues extends FieldValues = FieldValues> {
   name: string;
-  label: string;
+  label?: string;
   value?: unknown;
   defaultValue?: unknown;
   placeholder?: string;

--- a/packages/form-engine/src/core/field-registry.ts
+++ b/packages/form-engine/src/core/field-registry.ts
@@ -2,7 +2,6 @@ import type React from 'react';
 
 import { CheckboxField } from '../components/fields/CheckboxField';
 import { DateField } from '../components/fields/DateField';
-import { registerFieldComponent } from '../components/fields/FieldFactory';
 import type { FieldProps } from '../components/fields/types';
 import { NumberField } from '../components/fields/NumberField';
 import { SelectField } from '../components/fields/SelectField';
@@ -30,13 +29,21 @@ export class FieldRegistry {
     return FieldRegistry.instance;
   }
 
+  static reset(): void {
+    if (!FieldRegistry.instance) {
+      return;
+    }
+
+    FieldRegistry.instance.fields.clear();
+    FieldRegistry.instance = null;
+  }
+
   register(type: WidgetType, field: FieldComponent): void {
     if (this.fields.has(type)) {
       console.warn(`Field type ${type} is being overridden`);
     }
 
     this.fields.set(type, field);
-    registerFieldComponent(type, field.component);
   }
 
   get(type: WidgetType): FieldComponent | undefined {

--- a/packages/form-engine/tests/unit/field-registry.test.tsx
+++ b/packages/form-engine/tests/unit/field-registry.test.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { FieldFactory, FieldRegistry, initializeFieldRegistry } from '@form-engine/index';
+import type { FieldProps } from '@form-engine/components/fields/types';
+
+describe('FieldRegistry', () => {
+  beforeEach(() => {
+    FieldRegistry.reset();
+    initializeFieldRegistry();
+  });
+
+  afterEach(() => {
+    cleanup();
+    FieldRegistry.reset();
+  });
+
+  it('registers and retrieves custom field components', () => {
+    const registry = FieldRegistry.getInstance();
+
+    const CustomComponent: React.FC<FieldProps> = () => <div>Custom</div>;
+
+    registry.register('Custom', { component: CustomComponent });
+
+    const retrieved = registry.get('Custom');
+    expect(retrieved?.component).toBe(CustomComponent);
+    expect(registry.list()).toContain('Custom');
+  });
+
+  it('merges default props when rendering through the FieldFactory', () => {
+    const registry = FieldRegistry.getInstance();
+
+    const CustomComponent: React.FC<FieldProps> = ({ label }) => (
+      <div data-testid="custom-field">{label}</div>
+    );
+
+    registry.register('Custom', {
+      component: CustomComponent,
+      defaultProps: {
+        label: 'Default Label',
+      },
+    });
+
+    const { rerender } = render(<FieldFactory widget="Custom" name="custom" />);
+    expect(screen.getByTestId('custom-field')).toHaveTextContent('Default Label');
+
+    rerender(<FieldFactory widget="Custom" name="custom" label="Override" />);
+    expect(screen.getByTestId('custom-field')).toHaveTextContent('Override');
+  });
+});


### PR DESCRIPTION
## Summary
- integrate the field factory with the shared registry so registered metadata drives rendering
- add reset support and optional label handling in the registry contracts
- cover the registry/factory behaviour with focused unit tests

## Checklist
- [x] Implemented requirements from docs/form-builder/step-03-field-registry.md
- [x] Added/updated tests (Jest/RTL)
- [x] Code formatted with Prettier
- [x] CI passing (lint + typecheck + tests)

## Testing
- npm run lint
- npm run typecheck
- npm run build:form-engine
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cbb1cecbec832aa5bb856caaa18150