### PR TITLE
feat(form-engine): stabilize form renderer workflows (step 06)

### DIFF
--- a/packages/form-engine/src/components/fields/withFieldWrapper.tsx
+++ b/packages/form-engine/src/components/fields/withFieldWrapper.tsx
@@ -7,9 +7,9 @@ import { cn } from '../../utils/cn';
 import type { FieldProps } from './types';
 
 export function withFieldWrapper<P extends FieldProps>(
-  Component: React.ComponentType<P>
+  Component: React.ComponentType<P>,
 ): React.FC<P> {
-  const Wrapped: React.FC<P> = props => {
+  const Wrapped: React.FC<P> = (props) => {
     const {
       label,
       error,
@@ -32,16 +32,15 @@ export function withFieldWrapper<P extends FieldProps>(
     const descriptionId = description ? `${fieldId}-description` : undefined;
     const helpId = helpText ? `${fieldId}-help` : undefined;
 
-    const describedBy = [ariaDescribedBy, descriptionId, helpId, errorId]
-      .filter(Boolean)
-      .join(' ');
+    const describedBy = [ariaDescribedBy, descriptionId, helpId, errorId].filter(Boolean).join(' ');
 
     const componentProps: P = {
       ...(rest as P),
+      name,
       id: fieldId,
       ariaDescribedBy: describedBy || undefined,
       ariaInvalid: ariaInvalid ?? Boolean(errorMessage),
-      ariaRequired: ariaRequired ?? Boolean(required)
+      ariaRequired: ariaRequired ?? Boolean(required),
     };
 
     return (

--- a/packages/form-engine/src/renderer/ErrorSummary.tsx
+++ b/packages/form-engine/src/renderer/ErrorSummary.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import * as React from 'react';
+import type { FieldErrors } from 'react-hook-form';
+
+import { flattenFieldErrors } from './utils';
+
+interface ErrorSummaryProps {
+  errors: FieldErrors;
+  onFocusField?: (fieldName: string) => void;
+}
+
+export const ErrorSummary: React.FC<ErrorSummaryProps> = ({ errors, onFocusField }) => {
+  const items = React.useMemo(() => flattenFieldErrors(errors), [errors]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      role="alert"
+      aria-live="polite"
+      className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+    >
+      <p className="font-semibold">Please review the highlighted fields</p>
+      <ul className="mt-2 space-y-1">
+        {items.map((item) => (
+          <li key={item.name}>
+            <button
+              type="button"
+              onClick={() => onFocusField?.(item.name)}
+              className="font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {item.name}
+            </button>
+            {item.message ? `: ${item.message}` : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};

--- a/packages/form-engine/src/renderer/FormRenderer.tsx
+++ b/packages/form-engine/src/renderer/FormRenderer.tsx
@@ -5,9 +5,21 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { FieldFactory } from '../components/fields/FieldFactory';
 import type { JSONSchema, UnifiedFormSchema, ValidationError, WidgetType } from '../types';
-import { ValidationEngine } from '../validation/ajv-setup';
 import { TransitionEngine } from '../rules/transition-engine';
 import { VisibilityController } from '../rules/visibility-controller';
+import { ValidationEngine } from '../validation/ajv-setup';
+import { createAjvResolver } from '../validation/rhf-resolver';
+import { cn } from '../utils/cn';
+
+import { ErrorSummary } from './ErrorSummary';
+import { StepProgress } from './StepProgress';
+import {
+  flattenFieldErrors,
+  getStepFieldNames,
+  getStepStatus,
+  resolveStepSchema,
+  scrollToFirstError,
+} from './utils';
 
 export interface FormRendererProps {
   schema: UnifiedFormSchema;
@@ -20,58 +32,67 @@ export interface FormRendererProps {
   className?: string;
 }
 
-function resolveStepSchema(step: UnifiedFormSchema['steps'][number], formSchema: UnifiedFormSchema): JSONSchema {
-  if ('$ref' in step.schema) {
-    if (!step.schema.$ref) {
-      throw new Error('Step schema $ref is missing');
-    }
-    const reference = step.schema.$ref.replace('#/definitions/', '');
-    const resolved = formSchema.definitions?.[reference];
-    if (!resolved) {
-      throw new Error(`Unable to resolve schema reference: ${step.schema.$ref}`);
-    }
-    return resolved;
-  }
-  return step.schema;
-}
-
-function extractFields(stepSchema: JSONSchema, formSchema: UnifiedFormSchema) {
-  const properties = stepSchema.properties ?? {};
-  return Object.entries(properties).map(([name, propertySchema]) => {
-    const widgetConfig = formSchema.ui.widgets[name];
-    const widget: WidgetType = widgetConfig?.component ?? 'Text';
-    return {
-      name,
-      schema: propertySchema,
-      widget,
-      widgetConfig
-    };
-  });
-}
+type StepValidationResult = {
+  valid: boolean;
+  failedStep?: string;
+};
 
 export const FormRenderer: React.FC<FormRendererProps> = ({
   schema,
-  initialData = {},
+  initialData,
   onSubmit,
   onStepChange,
   onFieldChange,
   onValidationError,
   mode = 'create',
-  className
+  className,
 }) => {
+  const fallbackInitialDataRef = React.useRef<Record<string, unknown>>({});
+  const resolvedInitialData = initialData ?? fallbackInitialDataRef.current;
   const validationEngineRef = React.useRef(new ValidationEngine());
   const visibilityControllerRef = React.useRef(new VisibilityController());
   const transitionEngineRef = React.useRef(new TransitionEngine());
+  const currentStepSchemaRef = React.useRef<JSONSchema | undefined>(undefined);
 
   const [currentStepIndex, setCurrentStepIndex] = React.useState(0);
   const [stepHistory, setStepHistory] = React.useState<string[]>([]);
+  const [completedSteps, setCompletedSteps] = React.useState<string[]>([]);
+  const [errorSteps, setErrorSteps] = React.useState<string[]>([]);
   const [isSubmitting, setSubmitting] = React.useState(false);
 
+  const resolver = React.useCallback(
+    async (values: Record<string, unknown>, context: any, options: any) => {
+      const schemaForStep = currentStepSchemaRef.current;
+      if (!schemaForStep) {
+        return {
+          values,
+          errors: {},
+        };
+      }
+
+      const stepResolver = createAjvResolver(schemaForStep, validationEngineRef.current);
+      return stepResolver(values, context, options);
+    },
+    [],
+  );
+
   const methods = useForm({
-    defaultValues: initialData,
+    defaultValues: resolvedInitialData,
+    resolver,
     mode: 'onChange',
-    reValidateMode: 'onChange'
+    reValidateMode: 'onChange',
+    shouldUnregister: false,
   });
+
+  const { reset } = methods;
+
+  React.useEffect(() => {
+    reset(resolvedInitialData, {
+      keepDirty: false,
+      keepErrors: false,
+      keepDefaultValues: false,
+    });
+  }, [reset, resolvedInitialData]);
 
   const watchedValues = methods.watch();
 
@@ -79,9 +100,30 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
     return visibilityControllerRef.current.getVisibleSteps(schema, watchedValues);
   }, [schema, watchedValues]);
 
+  const sanitizedStepHistory = React.useMemo(
+    () => stepHistory.filter((step) => visibleSteps.includes(step)),
+    [stepHistory, visibleSteps],
+  );
+  React.useEffect(() => {
+    if (sanitizedStepHistory.length !== stepHistory.length) {
+      setStepHistory(sanitizedStepHistory);
+    }
+  }, [sanitizedStepHistory, stepHistory]);
+
+  React.useEffect(() => {
+    setCompletedSteps((prev) => prev.filter((step) => visibleSteps.includes(step)));
+  }, [visibleSteps]);
+
+  React.useEffect(() => {
+    setErrorSteps((prev) => prev.filter((step) => visibleSteps.includes(step)));
+  }, [visibleSteps]);
+
   const currentStepId = visibleSteps[currentStepIndex] ?? visibleSteps[0];
-  const currentStepConfig = schema.steps.find(step => step.id === currentStepId);
-  const currentStepSchema = currentStepConfig ? resolveStepSchema(currentStepConfig, schema) : undefined;
+  const currentStepConfig = schema.steps.find((step) => step.id === currentStepId);
+  const currentStepSchema = currentStepConfig
+    ? resolveStepSchema(currentStepConfig, schema)
+    : undefined;
+  currentStepSchemaRef.current = currentStepSchema;
 
   React.useEffect(() => {
     if (currentStepConfig && onStepChange) {
@@ -105,151 +147,385 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
     }
   }, [methods.formState.errors, onValidationError]);
 
-  const applyValidationErrors = (errors: ValidationError[]) => {
-    methods.clearErrors();
-    errors.forEach(error => {
-      const path = error.path.replace(/^\//, '').replace(/\//g, '.');
-      const name = (path || error.property || '').trim();
-      if (!name) return;
-      methods.setError(name as any, {
-        type: error.keyword || 'manual',
-        message: error.message
-      });
-    });
-  };
+  React.useEffect(() => {
+    if (currentStepIndex >= visibleSteps.length && visibleSteps.length > 0) {
+      setCurrentStepIndex(visibleSteps.length - 1);
+    }
+  }, [currentStepIndex, visibleSteps]);
 
-  const validateCurrentStep = async () => {
-    if (!currentStepSchema) return true;
-    const result = await validationEngineRef.current.validate(currentStepSchema, methods.getValues());
-    if (!result.valid) {
-      applyValidationErrors(result.errors);
-      return false;
-    }
-    methods.clearErrors();
-    return true;
-  };
+  const stepFieldMap = React.useMemo(() => {
+    return new Map(schema.steps.map((step) => [step.id, new Set(getStepFieldNames(step, schema))]));
+  }, [schema]);
 
-  const handleNext = async () => {
-    if (!currentStepSchema || !currentStepConfig) return;
-    const isValid = await validateCurrentStep();
-    if (!isValid) {
-      return;
-    }
-    const nextStep = transitionEngineRef.current.getNextStep(schema, currentStepConfig.id, methods.getValues());
-    if (!nextStep) {
-      if (currentStepIndex === visibleSteps.length - 1) {
-        await submitForm(methods.getValues());
-      }
-      return;
-    }
-    const nextIndex = visibleSteps.indexOf(nextStep);
-    if (nextIndex >= 0) {
-      setStepHistory(history => [...history, currentStepConfig.id]);
-      setCurrentStepIndex(nextIndex);
-    }
-  };
-
-  const handlePrevious = () => {
-    const previousStep = stepHistory[stepHistory.length - 1];
-    if (!previousStep) return;
-    const previousIndex = visibleSteps.indexOf(previousStep);
-    if (previousIndex >= 0) {
-      setStepHistory(history => history.slice(0, -1));
-      setCurrentStepIndex(previousIndex);
-    }
-  };
-
-  const validateAllSteps = async (data: Record<string, unknown>) => {
-    for (const step of schema.steps) {
-      const stepSchema = resolveStepSchema(step, schema);
-      const result = await validationEngineRef.current.validate(stepSchema, data);
-      if (!result.valid) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  const submitForm = async (data: Record<string, unknown>) => {
-    const currentValid = await validateCurrentStep();
-    if (!currentValid) {
-      return;
-    }
-    setSubmitting(true);
-    try {
-      const isValid = await validateAllSteps(data);
-      if (!isValid) {
-        onValidationError?.({ message: 'Validation failed' });
+  const stepErrorsFromState = React.useMemo(() => {
+    const flattened = flattenFieldErrors(methods.formState.errors);
+    const stepsWithErrors = new Set<string>();
+    flattened.forEach(({ name }) => {
+      const rootField = name.split('.')[0];
+      if (!rootField) {
         return;
       }
-      await onSubmit({
-        ...data,
-        metadata: {
-          submittedAt: new Date().toISOString(),
-          schemaVersion: schema.version
+      for (const [stepId, fields] of stepFieldMap.entries()) {
+        if (fields.has(rootField)) {
+          stepsWithErrors.add(stepId);
+          break;
         }
-      });
-    } finally {
-      setSubmitting(false);
-    }
-  };
+      }
+    });
+    return Array.from(stepsWithErrors);
+  }, [methods.formState.errors, stepFieldMap]);
 
-  if (!currentStepSchema || !currentStepConfig) {
+  React.useEffect(() => {
+    setErrorSteps((prev) => {
+      const unique = Array.from(new Set(stepErrorsFromState));
+      if (unique.length === prev.length && unique.every((step) => prev.includes(step))) {
+        return prev;
+      }
+      return unique;
+    });
+  }, [stepErrorsFromState]);
+
+  const errorStepSet = React.useMemo(() => new Set(errorSteps), [errorSteps]);
+
+  const applyValidationErrors = React.useCallback(
+    (errors: ValidationError[]) => {
+      methods.clearErrors();
+      errors.forEach((error) => {
+        const path = error.path.replace(/^\//, '').replace(/\//g, '.');
+        const name = (path || error.property || '').trim();
+        if (!name) return;
+        methods.setError(name as any, {
+          type: error.keyword || 'manual',
+          message: error.message,
+        });
+      });
+    },
+    [methods],
+  );
+
+  const markStepError = React.useCallback((stepId: string) => {
+    setErrorSteps((prev) => (prev.includes(stepId) ? prev : [...prev, stepId]));
+  }, []);
+
+  const clearStepError = React.useCallback((stepId: string) => {
+    setErrorSteps((prev) => prev.filter((item) => item !== stepId));
+  }, []);
+
+  const validateCurrentStep = React.useCallback(async () => {
+    if (!currentStepSchema || !currentStepId) {
+      return true;
+    }
+    const stepFields = Object.keys(currentStepSchema.properties ?? {});
+    const isValid = await methods.trigger(stepFields as any, { shouldFocus: false });
+    if (isValid) {
+      clearStepError(currentStepId);
+    } else {
+      markStepError(currentStepId);
+    }
+    return isValid;
+  }, [clearStepError, currentStepId, currentStepSchema, markStepError, methods]);
+
+  const validateAllSteps = React.useCallback(
+    async (data: Record<string, unknown>): Promise<StepValidationResult> => {
+      for (const stepId of visibleSteps) {
+        const stepConfig = schema.steps.find((step) => step.id === stepId);
+        if (!stepConfig) {
+          continue;
+        }
+        const stepSchema = resolveStepSchema(stepConfig, schema);
+        const result = await validationEngineRef.current.validate(stepSchema, data);
+        if (!result.valid) {
+          applyValidationErrors(result.errors);
+          markStepError(stepConfig.id);
+          return { valid: false, failedStep: stepConfig.id };
+        }
+        clearStepError(stepConfig.id);
+      }
+      return { valid: true };
+    },
+    [applyValidationErrors, clearStepError, markStepError, schema, visibleSteps],
+  );
+
+  const handleFormSubmit = React.useCallback(
+    async (data: Record<string, unknown>) => {
+      setSubmitting(true);
+      try {
+        const { valid, failedStep } = await validateAllSteps(data);
+        if (!valid) {
+          if (failedStep) {
+            const failedIndex = visibleSteps.indexOf(failedStep);
+            if (failedIndex >= 0) {
+              setCurrentStepIndex(failedIndex);
+            }
+          }
+          scrollToFirstError();
+          onValidationError?.(methods.formState.errors);
+          return;
+        }
+
+        const submissionData = {
+          ...data,
+          _meta: {
+            schemaId: schema.$id,
+            schemaVersion: schema.version,
+            submittedAt: new Date().toISOString(),
+            completedSteps: visibleSteps,
+          },
+        };
+
+        await onSubmit(submissionData);
+        setCompletedSteps((prev) => Array.from(new Set([...prev, ...visibleSteps])));
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      methods.formState.errors,
+      onSubmit,
+      onValidationError,
+      schema.$id,
+      schema.version,
+      validateAllSteps,
+      visibleSteps,
+    ],
+  );
+
+  const handleNext = React.useCallback(async () => {
+    if (!currentStepSchema || !currentStepConfig || !currentStepId) {
+      return;
+    }
+    const isValid = await validateCurrentStep();
+    if (!isValid) {
+      scrollToFirstError();
+      return;
+    }
+
+    clearStepError(currentStepId);
+    setCompletedSteps((prev) => (prev.includes(currentStepId) ? prev : [...prev, currentStepId]));
+
+    let nextStepId: string | undefined =
+      transitionEngineRef.current.getNextStep(schema, currentStepConfig.id, methods.getValues()) ??
+      undefined;
+    if (nextStepId && !visibleSteps.includes(nextStepId)) {
+      nextStepId = undefined;
+    }
+    if (!nextStepId) {
+      nextStepId = visibleSteps[currentStepIndex + 1];
+    }
+
+    if (nextStepId) {
+      const nextIndex = visibleSteps.indexOf(nextStepId);
+      if (nextIndex >= 0) {
+        setStepHistory((history) => [...history, currentStepId]);
+        setCurrentStepIndex(nextIndex);
+        return;
+      }
+    }
+
+    if (currentStepIndex === visibleSteps.length - 1) {
+      await handleFormSubmit(methods.getValues());
+    }
+  }, [
+    clearStepError,
+    currentStepConfig,
+    currentStepId,
+    currentStepIndex,
+    currentStepSchema,
+    handleFormSubmit,
+    methods,
+    schema,
+    validateCurrentStep,
+    visibleSteps,
+  ]);
+
+  const handlePrevious = React.useCallback(() => {
+    if (!currentStepId) {
+      return;
+    }
+    const previousFromHistory = stepHistory[stepHistory.length - 1];
+    const fallbackIndex = visibleSteps.indexOf(currentStepId) - 1;
+    const fallbackStep = fallbackIndex >= 0 ? visibleSteps[fallbackIndex] : undefined;
+    const targetStep = previousFromHistory ?? fallbackStep;
+    if (!targetStep) {
+      return;
+    }
+    const previousIndex = visibleSteps.indexOf(targetStep);
+    if (previousIndex >= 0) {
+      setStepHistory((history) => history.slice(0, -1));
+      setCurrentStepIndex(previousIndex);
+    }
+  }, [currentStepId, stepHistory, visibleSteps]);
+
+  const focusField = React.useCallback((fieldName: string) => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const escapedName =
+      typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+        ? CSS.escape(fieldName)
+        : fieldName.replace(/"/g, '\\"');
+    const selector = `[name="${escapedName}"]`;
+    const element = document.querySelector<HTMLElement>(selector);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (typeof element.focus === 'function') {
+        element.focus({ preventScroll: true });
+      }
+    }
+  }, []);
+
+  if (!currentStepSchema || !currentStepConfig || !visibleSteps.length) {
     return null;
   }
 
-  const fields = extractFields(currentStepSchema, schema).filter(field =>
-    visibilityControllerRef.current.isFieldVisible(field.schema, watchedValues)
+  const stepProperties = currentStepSchema.properties ?? {};
+  const visibleFields = visibilityControllerRef.current.getVisibleFields(
+    schema,
+    currentStepId,
+    watchedValues,
   );
+
+  const stepStatusList = visibleSteps.map((stepId) =>
+    getStepStatus(stepId, currentStepId, completedSteps, errorStepSet),
+  );
+
+  const widgetDefinitions = schema.ui?.widgets ?? {};
 
   return (
     <FormProvider {...methods}>
-      <form className={className} onSubmit={methods.handleSubmit(submitForm)}>
+      <form className={className} onSubmit={methods.handleSubmit(handleFormSubmit)} noValidate>
         <div className="space-y-6">
-          <header className="space-y-1">
-            <h2 className="text-lg font-semibold">{currentStepConfig.title}</h2>
-            {currentStepConfig.description ? (
-              <p className="text-sm text-muted-foreground">{currentStepConfig.description}</p>
-            ) : null}
-          </header>
+          <StepProgress
+            steps={visibleSteps.map((stepId, index) => ({
+              id: stepId,
+              title: schema.steps.find((step) => step.id === stepId)?.title ?? stepId,
+              status: stepStatusList[index],
+            }))}
+            currentStep={currentStepId}
+            onStepSelect={(stepId) => {
+              const targetIndex = visibleSteps.indexOf(stepId);
+              if (targetIndex >= 0 && targetIndex <= currentStepIndex) {
+                setCurrentStepIndex(targetIndex);
+              }
+            }}
+          />
 
-          <div className="space-y-4">
-            {fields.map(field => {
-              const widgetConfig = field.widgetConfig || {};
-              return (
-                <FieldFactory
-                  key={field.name}
-                  name={field.name}
-                  label={widgetConfig.label ?? field.name}
-                  widget={field.widget}
-                  placeholder={widgetConfig.placeholder}
-                  description={widgetConfig.description}
-                  helpText={widgetConfig.helpText}
-                  className={widgetConfig.className as string | undefined}
-                  disabled={mode === 'view' || widgetConfig.disabled}
-                  readOnly={widgetConfig.readOnly}
-                  control={methods.control}
-                  rules={undefined}
-                  options={widgetConfig.options}
-                />
-              );
-            })}
+          <div className="rounded-lg border bg-background shadow-sm">
+            <div className="border-b p-6">
+              <h2 className="text-lg font-semibold text-foreground">{currentStepConfig.title}</h2>
+              {currentStepConfig.description ? (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {currentStepConfig.description}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-6 p-6">
+              <div className="space-y-4">
+                {Object.entries(stepProperties).map(([fieldName, fieldSchema]) => {
+                  if (!visibleFields.includes(fieldName)) {
+                    return null;
+                  }
+
+                  const uiConfig = widgetDefinitions[fieldName];
+                  if (!uiConfig) {
+                    console.warn(`No widget configuration found for field: ${fieldName}`);
+                    return null;
+                  }
+
+                  const {
+                    component,
+                    label,
+                    placeholder,
+                    helpText,
+                    description,
+                    className: widgetClassName,
+                    options,
+                    disabled,
+                    readOnly,
+                    ...componentProps
+                  } = uiConfig;
+
+                  const widget: WidgetType = component ?? 'Text';
+                  const fieldError =
+                    methods.formState.errors?.[fieldName as keyof typeof methods.formState.errors];
+                  const errorMessage = (() => {
+                    if (fieldError && typeof fieldError === 'object' && 'message' in fieldError) {
+                      return (fieldError as { message?: string }).message ?? 'Invalid value';
+                    }
+                    if (typeof fieldError === 'string') {
+                      return fieldError;
+                    }
+                    return undefined;
+                  })();
+
+                  const isRequired = Array.isArray(currentStepSchema.required)
+                    ? currentStepSchema.required.includes(fieldName)
+                    : false;
+
+                  return (
+                    <FieldFactory
+                      key={fieldName}
+                      name={fieldName}
+                      label={label ?? fieldName}
+                      widget={widget}
+                      placeholder={placeholder}
+                      description={description}
+                      helpText={helpText}
+                      className={widgetClassName as string | undefined}
+                      disabled={mode === 'view' || disabled}
+                      readOnly={readOnly}
+                      required={isRequired}
+                      control={methods.control}
+                      rules={undefined}
+                      options={options}
+                      componentProps={componentProps as Record<string, unknown>}
+                      error={errorMessage}
+                    />
+                  );
+                })}
+              </div>
+
+              <ErrorSummary errors={methods.formState.errors} onFocusField={focusField} />
+            </div>
+
+            <div
+              className={cn('flex items-center justify-between gap-4 border-t p-6', 'bg-muted/30')}
+            >
+              <button
+                type="button"
+                onClick={handlePrevious}
+                disabled={currentStepIndex === 0}
+                className={cn(
+                  'rounded-md border border-input px-4 py-2 text-sm font-medium text-foreground transition-colors',
+                  currentStepIndex === 0 && 'opacity-50',
+                )}
+              >
+                Previous
+              </button>
+
+              <div className="flex gap-2">
+                {currentStepIndex < visibleSteps.length - 1 ? (
+                  <button
+                    type="button"
+                    onClick={handleNext}
+                    className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                    disabled={isSubmitting}
+                  >
+                    Next
+                  </button>
+                ) : (
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    {isSubmitting ? 'Submitting…' : 'Submit'}
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
-
-          <footer className="flex items-center justify-between gap-4">
-            <button type="button" onClick={handlePrevious} disabled={stepHistory.length === 0} className="rounded border px-4 py-2">
-              Previous
-            </button>
-            {currentStepIndex < visibleSteps.length - 1 ? (
-              <button type="button" onClick={handleNext} className="rounded bg-primary px-4 py-2 text-primary-foreground">
-                Next
-              </button>
-            ) : (
-              <button type="submit" disabled={isSubmitting} className="rounded bg-primary px-4 py-2 text-primary-foreground">
-                {isSubmitting ? 'Submitting…' : 'Submit'}
-              </button>
-            )}
-          </footer>
         </div>
       </form>
     </FormProvider>

--- a/packages/form-engine/src/renderer/StepProgress.tsx
+++ b/packages/form-engine/src/renderer/StepProgress.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import * as React from 'react';
+import { Check, X } from 'lucide-react';
+
+import { cn } from '../utils/cn';
+
+import type { StepStatus } from './utils';
+
+interface StepProgressProps {
+  steps: Array<{
+    id: string;
+    title: string;
+    status: StepStatus;
+  }>;
+  currentStep: string;
+  orientation?: 'horizontal' | 'vertical';
+  showLabels?: boolean;
+  onStepSelect?: (stepId: string) => void;
+}
+
+export const StepProgress: React.FC<StepProgressProps> = ({
+  steps,
+  currentStep,
+  orientation = 'horizontal',
+  showLabels = true,
+  onStepSelect,
+}) => {
+  const isHorizontal = orientation === 'horizontal';
+
+  return (
+    <nav
+      className={cn('flex', isHorizontal ? 'flex-row items-center' : 'flex-col')}
+      aria-label="Form progress"
+    >
+      {steps.map((step, index) => {
+        const isLast = index === steps.length - 1;
+
+        return (
+          <div
+            key={step.id}
+            className={cn('flex', isHorizontal ? 'flex-row items-center' : 'flex-col')}
+          >
+            <StepIndicator
+              number={index + 1}
+              status={step.status}
+              title={step.title}
+              showLabel={showLabels}
+              isActive={step.id === currentStep}
+              onSelect={() => onStepSelect?.(step.id)}
+            />
+
+            {!isLast && (
+              <StepConnector orientation={orientation} isCompleted={step.status === 'completed'} />
+            )}
+          </div>
+        );
+      })}
+    </nav>
+  );
+};
+
+interface StepIndicatorProps {
+  number: number;
+  status: StepStatus;
+  title: string;
+  showLabel: boolean;
+  isActive: boolean;
+  onSelect?: () => void;
+}
+
+const StepIndicator: React.FC<StepIndicatorProps> = ({
+  number,
+  status,
+  title,
+  showLabel,
+  isActive,
+  onSelect,
+}) => {
+  const content = React.useMemo(() => {
+    switch (status) {
+      case 'completed':
+        return <Check className="h-4 w-4" aria-hidden="true" />;
+      case 'error':
+        return <X className="h-4 w-4" aria-hidden="true" />;
+      default:
+        return number;
+    }
+  }, [number, status]);
+
+  const handleClick = () => {
+    if (status === 'completed' || status === 'error' || isActive) {
+      onSelect?.();
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center text-center">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!onSelect || (!isActive && status === 'upcoming')}
+        className={cn(
+          'flex h-10 w-10 items-center justify-center rounded-full border-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+          status === 'current' && 'border-primary bg-primary text-primary-foreground',
+          status === 'completed' && 'border-primary bg-primary text-primary-foreground',
+          status === 'upcoming' && 'border-muted-foreground/40 bg-background text-muted-foreground',
+          status === 'error' && 'border-destructive bg-destructive text-destructive-foreground',
+          isActive && status !== 'current' && 'ring-2 ring-primary ring-offset-2',
+        )}
+        aria-current={isActive ? 'step' : undefined}
+      >
+        {content}
+      </button>
+
+      {showLabel ? (
+        <span
+          className={cn(
+            'mt-2 text-sm',
+            isActive ? 'font-semibold text-foreground' : 'font-normal text-muted-foreground',
+          )}
+        >
+          {title}
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+interface StepConnectorProps {
+  orientation: 'horizontal' | 'vertical';
+  isCompleted: boolean;
+}
+
+const StepConnector: React.FC<StepConnectorProps> = ({ orientation, isCompleted }) => {
+  const isHorizontal = orientation === 'horizontal';
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'mx-2 block transition-colors',
+        isHorizontal ? 'h-0.5 w-12' : 'h-12 w-0.5',
+        isCompleted ? 'bg-primary' : 'bg-muted-foreground/30',
+      )}
+    />
+  );
+};

--- a/packages/form-engine/src/renderer/utils.ts
+++ b/packages/form-engine/src/renderer/utils.ts
@@ -1,0 +1,108 @@
+import type { FieldErrors } from 'react-hook-form';
+
+import type { FormStep, JSONSchema, UnifiedFormSchema } from '../types';
+
+export type StepStatus = 'completed' | 'current' | 'upcoming' | 'error';
+
+export function resolveStepSchema(step: FormStep, schema: UnifiedFormSchema): JSONSchema {
+  if ('$ref' in step.schema && typeof step.schema.$ref === 'string') {
+    const refPath = step.schema.$ref.replace('#/', '').split('/');
+    let resolved: any = schema;
+    for (const segment of refPath) {
+      resolved = resolved?.[segment];
+      if (resolved === undefined) {
+        throw new Error(`Unable to resolve schema reference: ${step.schema.$ref}`);
+      }
+    }
+    return resolved as JSONSchema;
+  }
+
+  return step.schema as JSONSchema;
+}
+
+export function getStepFieldNames(step: FormStep, schema: UnifiedFormSchema): string[] {
+  const stepSchema = resolveStepSchema(step, schema);
+  return stepSchema.properties ? Object.keys(stepSchema.properties) : [];
+}
+
+export function getStepStatus(
+  stepId: string,
+  currentStep: string | undefined,
+  completedSteps: string[],
+  errorSteps: Set<string>,
+): StepStatus {
+  if (stepId === currentStep) {
+    return errorSteps.has(stepId) ? 'error' : 'current';
+  }
+  if (errorSteps.has(stepId)) {
+    return 'error';
+  }
+  if (completedSteps.includes(stepId)) {
+    return 'completed';
+  }
+  return 'upcoming';
+}
+
+export interface FlattenedFieldError {
+  name: string;
+  message?: string;
+}
+
+export function flattenFieldErrors(errors: FieldErrors, parentPath = ''): FlattenedFieldError[] {
+  const result: FlattenedFieldError[] = [];
+
+  Object.entries(errors ?? {}).forEach(([key, value]) => {
+    if (!value) {
+      return;
+    }
+
+    const path = parentPath ? `${parentPath}.${key}` : key;
+
+    if (isFieldError(value)) {
+      result.push({ name: path, message: value.message });
+      if (value.types) {
+        Object.entries(value.types).forEach(([typeKey, typeValue]) => {
+          result.push({ name: `${path}.${typeKey}`, message: String(typeValue) });
+        });
+      }
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => {
+        if (item) {
+          result.push(...flattenFieldErrors(item as FieldErrors, `${path}[${index}]`));
+        }
+      });
+      return;
+    }
+
+    if (typeof value === 'object') {
+      result.push(...flattenFieldErrors(value as FieldErrors, path));
+    }
+  });
+
+  return result;
+}
+
+export function scrollToFirstError(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const firstError = document.querySelector<HTMLElement>('[aria-invalid="true"]');
+  if (firstError) {
+    firstError.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (typeof firstError.focus === 'function') {
+      firstError.focus({ preventScroll: true });
+    }
+  }
+}
+
+function isFieldError(
+  value: unknown,
+): value is { message?: string; types?: Record<string, unknown> } {
+  return (
+    Boolean(value) && typeof value === 'object' && 'type' in (value as Record<string, unknown>)
+  );
+}

--- a/packages/form-engine/tests/unit/FormRenderer.test.tsx
+++ b/packages/form-engine/tests/unit/FormRenderer.test.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { UnifiedFormSchema } from '@form-engine/types';
+import { FormRenderer } from '@form-engine/index';
+
+const buildSchema = (): UnifiedFormSchema => ({
+  $id: 'test-form',
+  version: '1.0.0',
+  metadata: {
+    title: 'Test Form',
+    description: 'Test form description',
+    sensitivity: 'low',
+  },
+  steps: [
+    {
+      id: 'personal',
+      title: 'Personal Info',
+      schema: {
+        type: 'object',
+        properties: {
+          firstName: { type: 'string', minLength: 1 },
+          lastName: { type: 'string', minLength: 1 },
+        },
+        required: ['firstName', 'lastName'],
+      },
+    },
+    {
+      id: 'contact',
+      title: 'Contact Info',
+      schema: {
+        type: 'object',
+        properties: {
+          email: { type: 'string', format: 'email' },
+          phone: { type: 'string' },
+        },
+        required: ['email'],
+      },
+    },
+  ],
+  transitions: [{ from: 'personal', to: 'contact', default: true }],
+  ui: {
+    widgets: {
+      firstName: { component: 'Text', label: 'First Name' },
+      lastName: { component: 'Text', label: 'Last Name' },
+      email: { component: 'Email', label: 'Email' },
+      phone: { component: 'Phone', label: 'Phone' },
+    },
+  },
+});
+
+describe('FormRenderer', () => {
+  it('renders the first step fields by default', async () => {
+    const schema = buildSchema();
+
+    render(<FormRenderer schema={schema} onSubmit={jest.fn()} />);
+
+    expect(await screen.findByRole('textbox', { name: /first name/i })).toBeInTheDocument();
+    expect(await screen.findByRole('textbox', { name: /last name/i })).toBeInTheDocument();
+  });
+
+  it('displays validation errors when moving forward without completing required fields', async () => {
+    const schema = buildSchema();
+
+    render(<FormRenderer schema={schema} onSubmit={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('navigates to the next step when the current step is valid', async () => {
+    const schema = buildSchema();
+
+    render(<FormRenderer schema={schema} onSubmit={jest.fn()} />);
+
+    fireEvent.change(await screen.findByRole('textbox', { name: /first name/i }), {
+      target: { value: 'John' },
+    });
+    fireEvent.change(await screen.findByRole('textbox', { name: /last name/i }), {
+      target: { value: 'Doe' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /email/i })).toBeInTheDocument();
+    });
+  });
+
+  it('submits the form data with metadata when all steps are valid', async () => {
+    const schema = buildSchema();
+    const onSubmit = jest.fn();
+
+    render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+    fireEvent.change(await screen.findByRole('textbox', { name: /first name/i }), {
+      target: { value: 'Jane' },
+    });
+    fireEvent.change(await screen.findByRole('textbox', { name: /last name/i }), {
+      target: { value: 'Doe' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {
+        target: { value: 'jane@example.com' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane@example.com',
+          _meta: expect.objectContaining({
+            schemaId: 'test-form',
+            schemaVersion: '1.0.0',
+          }),
+        }),
+      );
+    });
+  });
+
+  it('respects step visibility rules', async () => {
+    const baseSchema = buildSchema();
+    const conditionalSchema: UnifiedFormSchema = {
+      ...baseSchema,
+      steps: [
+        ...baseSchema.steps,
+        {
+          id: 'conditional',
+          title: 'Conditional Step',
+          schema: { type: 'object', properties: {} },
+          visibleWhen: {
+            op: 'eq',
+            left: '$.showConditional',
+            right: true,
+          },
+        },
+      ],
+    };
+
+    const { rerender } = render(
+      <FormRenderer
+        schema={conditionalSchema}
+        initialData={{ showConditional: false }}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Conditional Step')).not.toBeInTheDocument();
+
+    rerender(
+      <FormRenderer
+        schema={conditionalSchema}
+        initialData={{ showConditional: true }}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Conditional Step')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- forward field names through the shared wrapper so React Hook Form controllers receive valid identifiers
- guard form initialization with a stable default state and reset flow to keep multi-step schemas working in tests and runtime
- add a dedicated renderer test suite that covers step rendering, validation, submission metadata, and visibility toggles

## Checklist
- [x] Dynamic form rendering from schema
- [x] Multi-step navigation with validation
- [x] Progress indicator showing step status
- [x] Field visibility based on rules
- [x] Form submission with metadata
- [x] Error summary with field navigation
- [ ] Keyboard navigation support
- [ ] Responsive design for mobile/desktop

## CI
- ✅ `npm run lint`
- ✅ `npm run typecheck`
- ✅ `npm test`
- ✅ `npm run build`
- ✅ `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_68cc1eb133bc832a8fb45ac7eafbdb2d