### PR TITLE
feat(form-engine): performance analytics (step 09)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle": "^1.1.1",
         "@radix-ui/react-toggle-group": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
+        "@types/gtag.js": "^0.0.20",
         "@xstate/react": "^4.0.0",
         "ajv": "^8.12.0",
         "ajv-errors": "^3.0.0",
@@ -69,6 +70,7 @@
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.6",
+        "web-vitals": "^5.1.0",
         "xstate": "^5.5.0",
         "zod": "latest"
       },
@@ -3817,6 +3819,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/gtag.js": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
+      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -28996,6 +29004,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-toggle": "^1.1.1",
     "@radix-ui/react-toggle-group": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
+    "@types/gtag.js": "^0.0.20",
     "@xstate/react": "^4.0.0",
     "ajv": "^8.12.0",
     "ajv-errors": "^3.0.0",
@@ -77,6 +78,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
+    "web-vitals": "^5.1.0",
     "xstate": "^5.5.0",
     "zod": "latest"
   },

--- a/packages/form-engine/src/analytics/FormAnalytics.ts
+++ b/packages/form-engine/src/analytics/FormAnalytics.ts
@@ -1,98 +1,474 @@
-export interface AnalyticsEvent {
-  name: string;
-  data: unknown;
-  timestamp: number;
-  sessionId: string;
+import type {
+  AnalyticsEvent,
+  FormAnalyticsConfig,
+  PerformanceMetric,
+  SessionMetrics,
+} from '../types';
+
+interface TrackEventOptions
+  extends Partial<
+    Pick<AnalyticsEvent, 'category' | 'formId' | 'schemaVersion' | 'stepId' | 'fieldName'>
+  > {
+  sensitive?: boolean;
 }
+
+const DEFAULT_CONFIG: Required<
+  Pick<FormAnalyticsConfig, 'sampling' | 'sensitive' | 'bufferSize' | 'flushInterval'>
+> = {
+  sampling: 1,
+  sensitive: true,
+  bufferSize: 25,
+  flushInterval: 8000,
+};
 
 export class FormAnalytics {
   private events: AnalyticsEvent[] = [];
+  private sessionId: string;
+  private config: FormAnalyticsConfig;
+  private performanceObserver?: PerformanceObserver;
+  private sessionMetrics: SessionMetrics;
+  private flushTimer?: ReturnType<typeof setInterval>;
+  private listenersAttached = false;
 
-  initialize(formId: string, schemaVersion: string): void {
-    this.trackEvent('form_viewed', { formId, schemaVersion });
-    this.initPerformanceMonitoring();
+  constructor(config: FormAnalyticsConfig) {
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+    };
+
+    this.sessionId = this.generateSessionId();
+    this.sessionMetrics = {
+      startTime: Date.now(),
+      completedSteps: [],
+      errors: 0,
+      validationAttempts: 0,
+      fieldInteractions: 0,
+    };
+
+    if (this.config.enabled && typeof window !== 'undefined') {
+      this.initialize();
+    }
   }
 
-  trackEvent(eventName: string, data: unknown, sensitive = false): void {
-    const payload = sensitive ? this.sanitizeData(data) : data;
+  trackEvent(
+    eventName: string,
+    data: Record<string, any> = {},
+    category?: AnalyticsEvent['category'],
+    options: TrackEventOptions = {},
+  ): void {
+    if (!this.config.enabled || !this.shouldTrack()) {
+      return;
+    }
+
+    const shouldSanitize = options.sensitive ?? this.config.sensitive ?? false;
+    const payload = shouldSanitize ? this.sanitizeData(data) : data;
+
     const event: AnalyticsEvent = {
       name: eventName,
+      category: options.category ?? category,
       data: payload,
       timestamp: Date.now(),
-      sessionId: this.getSessionId()
+      sessionId: this.sessionId,
+      formId: options.formId ?? (typeof data.formId === 'string' ? data.formId : undefined),
+      schemaVersion:
+        options.schemaVersion ??
+        (typeof data.schemaVersion === 'string' ? data.schemaVersion : undefined),
+      stepId: options.stepId ?? (typeof data.stepId === 'string' ? data.stepId : undefined),
+      fieldName:
+        options.fieldName ?? (typeof data.fieldName === 'string' ? data.fieldName : undefined),
     };
+
     this.events.push(event);
-    this.dispatch(event).catch(error => console.error('Failed to send analytics event', error));
+    this.updateSessionMetrics(eventName, data);
+
+    if (this.config.bufferSize && this.events.length >= this.config.bufferSize) {
+      if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+        window.requestIdleCallback(() => {
+          void this.flush();
+        });
+      } else {
+        void this.flush();
+      }
+    }
   }
 
-  measureStepTransition(from: string, to: string): () => void {
-    if (typeof performance === 'undefined') {
-      return () => undefined;
+  measureStepTransition(from: string, to: string): (() => void) | undefined {
+    if (typeof performance === 'undefined' || typeof performance.mark !== 'function') {
+      return undefined;
     }
+
     const markName = `step_${from}_to_${to}`;
     performance.mark(`${markName}_start`);
+
     return () => {
       performance.mark(`${markName}_end`);
       performance.measure(markName, `${markName}_start`, `${markName}_end`);
+      performance.clearMarks(`${markName}_start`);
+      performance.clearMarks(`${markName}_end`);
     };
   }
 
-  private async dispatch(event: AnalyticsEvent): Promise<void> {
-    if (typeof fetch === 'undefined') {
-      return;
+  measureValidation(stepId: string): (() => void) | undefined {
+    if (typeof performance === 'undefined' || typeof performance.mark !== 'function') {
+      return undefined;
     }
-    try {
-      await fetch('/api/analytics', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(event)
-      });
-    } catch (error) {
-      console.warn('Analytics dispatch failed', error);
+
+    const markName = `validation_${stepId}`;
+    performance.mark(`${markName}_start`);
+
+    return () => {
+      performance.mark(`${markName}_end`);
+      performance.measure(markName, `${markName}_start`, `${markName}_end`);
+      performance.clearMarks(`${markName}_start`);
+      performance.clearMarks(`${markName}_end`);
+    };
+  }
+
+  getSessionId(): string {
+    return this.sessionId;
+  }
+
+  getSessionMetrics(): SessionMetrics {
+    return { ...this.sessionMetrics, completedSteps: [...this.sessionMetrics.completedSteps] };
+  }
+
+  destroy(): void {
+    if (this.performanceObserver) {
+      this.performanceObserver.disconnect();
     }
+
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+
+    if (this.listenersAttached && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+      window.removeEventListener('beforeunload', this.handleUnload);
+      this.listenersAttached = false;
+    }
+
+    void this.flush();
+  }
+
+  private initialize(): void {
+    this.initPerformanceMonitoring();
+    this.initEventListeners();
+    this.startFlushTimer();
+  }
+
+  private shouldTrack(): boolean {
+    const sampling = this.config.sampling ?? 1;
+    if (sampling >= 1) {
+      return true;
+    }
+
+    if (sampling <= 0) {
+      return false;
+    }
+
+    return Math.random() <= sampling;
+  }
+
+  private updateSessionMetrics(eventName: string, data: Record<string, any>): void {
+    switch (eventName) {
+      case 'step_completed':
+        if (
+          typeof data.stepId === 'string' &&
+          !this.sessionMetrics.completedSteps.includes(data.stepId)
+        ) {
+          this.sessionMetrics.completedSteps.push(data.stepId);
+        }
+        break;
+      case 'validation_error':
+        this.sessionMetrics.errors += 1;
+        break;
+      case 'validation_attempt':
+        this.sessionMetrics.validationAttempts += 1;
+        break;
+      case 'field_changed':
+        this.sessionMetrics.fieldInteractions += 1;
+        break;
+      case 'form_abandoned':
+        if (typeof data.stepId === 'string') {
+          this.sessionMetrics.abandonedAt = data.stepId;
+        }
+        this.sessionMetrics.endTime = Date.now();
+        break;
+      case 'form_completed':
+      case 'form_submitted':
+        this.sessionMetrics.endTime = Date.now();
+        break;
+      default:
+        break;
+    }
+  }
+
+  private sanitizeData(data: any): any {
+    const sensitiveKeys = ['email', 'phone', 'ssn', 'creditcard', 'credit_card', 'password'];
+
+    const sanitizeValue = (value: any, path = ''): any => {
+      if (Array.isArray(value)) {
+        return value.map((item, index) => sanitizeValue(item, `${path}.${index}`));
+      }
+
+      if (value && typeof value === 'object') {
+        return Object.entries(value).reduce<Record<string, any>>((acc, [key, val]) => {
+          const currentPath = path ? `${path}.${key}` : key;
+          acc[key] = sanitizeValue(val, currentPath);
+          return acc;
+        }, {});
+      }
+
+      const fieldName = path.split('.').pop() ?? '';
+      if (sensitiveKeys.some((sensitiveKey) => fieldName.toLowerCase().includes(sensitiveKey))) {
+        return '[REDACTED]';
+      }
+
+      return value;
+    };
+
+    return sanitizeValue(data);
   }
 
   private initPerformanceMonitoring(): void {
-    if (typeof PerformanceObserver === 'undefined') {
+    if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') {
       return;
     }
-    const observer = new PerformanceObserver(list => {
-      for (const entry of list.getEntries()) {
-        if (entry.entryType === 'measure') {
-          this.trackEvent('performance', {
-            metric: entry.name,
-            duration: entry.duration,
-            start: entry.startTime
-          });
-          if (entry.duration > 150) {
-            console.warn(`Performance threshold exceeded for ${entry.name}`);
-          }
+
+    try {
+      this.performanceObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          this.trackPerformanceEntry(entry);
         }
+      });
+
+      this.performanceObserver.observe({
+        entryTypes: ['measure', 'navigation', 'resource', 'paint'],
+      });
+    } catch (error) {
+      console.warn('Performance monitoring not available:', error);
+    }
+  }
+
+  private trackPerformanceEntry(entry: PerformanceEntry): void {
+    if (!this.config.enabled) {
+      return;
+    }
+
+    const metric: PerformanceMetric = {
+      name: entry.name,
+      value: 'duration' in entry ? (entry as PerformanceEntry & { duration: number }).duration : 0,
+      unit: 'ms',
+      timestamp: entry.startTime ?? Date.now(),
+      metadata: {
+        entryType: entry.entryType,
+        detail:
+          typeof (entry as PerformanceEntry & { toJSON?: () => unknown }).toJSON === 'function'
+            ? (entry as PerformanceEntry & { toJSON: () => unknown }).toJSON()
+            : undefined,
+      },
+    };
+
+    if (this.config.performanceBudgets) {
+      this.checkPerformanceBudget(entry);
+    }
+
+    this.trackEvent('performance_metric', metric, 'performance', { sensitive: false });
+  }
+
+  private checkPerformanceBudget(entry: PerformanceEntry): void {
+    const budgets = this.config.performanceBudgets;
+    if (!budgets) {
+      return;
+    }
+
+    const duration =
+      'duration' in entry ? (entry as PerformanceEntry & { duration: number }).duration : undefined;
+    if (duration === undefined) {
+      return;
+    }
+
+    let budget: number | undefined;
+    type BudgetKey = keyof NonNullable<FormAnalyticsConfig['performanceBudgets']>;
+    let metricKey: BudgetKey | undefined;
+
+    if (entry.name.includes('step_')) {
+      budget = budgets.stepTransition;
+      metricKey = 'stepTransition';
+    } else if (entry.name.includes('validation_')) {
+      budget = budgets.validation;
+      metricKey = 'validation';
+    } else if (entry.entryType === 'navigation') {
+      budget = budgets.initialLoad;
+      metricKey = 'initialLoad';
+    }
+
+    if (budget && duration > budget) {
+      console.warn(
+        `⚠️ Performance budget exceeded for ${metricKey}: ${duration.toFixed(2)}ms (budget: ${budget}ms)`,
+      );
+      this.trackEvent(
+        'performance_budget_exceeded',
+        {
+          metric: metricKey,
+          actual: duration,
+          budget,
+          exceeded: duration - budget,
+        },
+        'performance',
+        { sensitive: false },
+      );
+    }
+  }
+
+  private initEventListeners(): void {
+    if (
+      this.listenersAttached ||
+      typeof document === 'undefined' ||
+      typeof window === 'undefined'
+    ) {
+      return;
+    }
+
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    window.addEventListener('beforeunload', this.handleUnload);
+    this.listenersAttached = true;
+
+    this.trackEvent(
+      'form_viewed',
+      {
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        referrer: typeof document !== 'undefined' ? document.referrer : undefined,
+      },
+      'navigation',
+    );
+  }
+
+  private handleVisibilityChange = (): void => {
+    if (!this.config.enabled) {
+      return;
+    }
+
+    if (typeof document !== 'undefined' && document.hidden) {
+      this.trackEvent(
+        'form_hidden',
+        {
+          duration: Date.now() - this.sessionMetrics.startTime,
+        },
+        'navigation',
+      );
+      void this.flush();
+    } else {
+      this.trackEvent('form_visible', {}, 'navigation');
+    }
+  };
+
+  private handleUnload = (): void => {
+    if (!this.config.enabled) {
+      return;
+    }
+
+    this.sessionMetrics.endTime = Date.now();
+    this.trackEvent('session_end', this.sessionMetrics, 'navigation');
+    this.sendBeacon();
+  };
+
+  private startFlushTimer(): void {
+    if (!this.config.flushInterval || this.config.flushInterval <= 0) {
+      return;
+    }
+
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, this.config.flushInterval);
+  }
+
+  private async flush(): Promise<void> {
+    if (!this.config.enabled || this.events.length === 0) {
+      return;
+    }
+
+    const eventsToSend = [...this.events];
+    this.events = [];
+
+    try {
+      await this.sendEvents(eventsToSend);
+    } catch (error) {
+      console.error('Failed to send analytics:', error);
+      this.events.unshift(...eventsToSend);
+    }
+  }
+
+  private async sendEvents(events: AnalyticsEvent[]): Promise<void> {
+    if (!this.config.endpoint) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('Analytics events:', events);
       }
+      return;
+    }
+
+    if (typeof fetch === 'undefined') {
+      return;
+    }
+
+    const response = await fetch(this.config.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        events,
+        sessionId: this.sessionId,
+        timestamp: Date.now(),
+      }),
     });
-    observer.observe({ entryTypes: ['measure'] });
-  }
 
-  private sanitizeData(data: unknown): unknown {
-    if (typeof data !== 'object' || data === null) {
-      return data;
+    if (!response.ok) {
+      throw new Error(`Analytics API error: ${response.status}`);
     }
-    return Object.keys(data as Record<string, unknown>).reduce<Record<string, unknown>>((acc, key) => {
-      acc[key] = '[redacted]';
-      return acc;
-    }, {});
   }
 
-  private getSessionId(): string {
+  private sendBeacon(): void {
+    if (
+      typeof navigator === 'undefined' ||
+      typeof navigator.sendBeacon !== 'function' ||
+      !this.config.endpoint
+    ) {
+      return;
+    }
+
+    const payload = JSON.stringify({
+      events: this.events,
+      sessionId: this.sessionId,
+      sessionMetrics: this.sessionMetrics,
+    });
+
+    navigator.sendBeacon(this.config.endpoint, payload);
+  }
+
+  private generateSessionId(): string {
     if (typeof window === 'undefined') {
-      return 'server-session';
+      return `session_${Date.now()}`;
     }
-    const existing = window.sessionStorage.getItem('cml-form-session');
-    if (existing) {
-      return existing;
+
+    const storageKey = 'cml-form-session';
+    try {
+      const existing = window.sessionStorage.getItem(storageKey);
+      if (existing) {
+        return existing;
+      }
+      const id =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : this.randomId();
+      window.sessionStorage.setItem(storageKey, id);
+      return id;
+    } catch (error) {
+      console.warn('Unable to access sessionStorage for analytics session id', error);
+      return this.randomId();
     }
-    const id = crypto.randomUUID();
-    window.sessionStorage.setItem('cml-form-session', id);
-    return id;
+  }
+
+  private randomId(): string {
+    return `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 }

--- a/packages/form-engine/src/components/PerformanceDashboard.tsx
+++ b/packages/form-engine/src/components/PerformanceDashboard.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import * as React from 'react';
+
+interface PerformanceDashboardProps {
+  show?: boolean;
+}
+
+interface DashboardMetrics {
+  pageLoad?: number;
+  domReady?: number;
+  stepTransitions: Array<{ name: string; duration: number }>;
+  validations: Array<{ name: string; duration: number }>;
+  memory?: { used: string; total: string } | null;
+}
+
+const INITIAL_METRICS: DashboardMetrics = {
+  stepTransitions: [],
+  validations: [],
+  memory: null,
+};
+
+export const PerformanceDashboard: React.FC<PerformanceDashboardProps> = ({ show = false }) => {
+  const [metrics, setMetrics] = React.useState<DashboardMetrics>(INITIAL_METRICS);
+  const [isVisible, setIsVisible] = React.useState(show);
+
+  React.useEffect(() => {
+    if (!isVisible || typeof performance === 'undefined') {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      const navigation = performance.getEntriesByType('navigation')[0] as
+        | PerformanceNavigationTiming
+        | undefined;
+      const measures = performance.getEntriesByType('measure');
+
+      setMetrics({
+        pageLoad:
+          navigation && navigation.loadEventEnd && navigation.fetchStart
+            ? navigation.loadEventEnd - navigation.fetchStart
+            : undefined,
+        domReady:
+          navigation && navigation.domContentLoadedEventEnd && navigation.fetchStart
+            ? navigation.domContentLoadedEventEnd - navigation.fetchStart
+            : undefined,
+        stepTransitions: measures
+          .filter((measure) => measure.name.includes('step_'))
+          .map((measure) => ({
+            name: measure.name,
+            duration: Number(measure.duration.toFixed(2)),
+          })),
+        validations: measures
+          .filter((measure) => measure.name.includes('validation_'))
+          .map((measure) => ({
+            name: measure.name,
+            duration: Number(measure.duration.toFixed(2)),
+          })),
+        memory: (
+          performance as Performance & {
+            memory?: { usedJSHeapSize: number; totalJSHeapSize: number };
+          }
+        ).memory
+          ? {
+              used: (
+                ((performance as Performance & { memory: { usedJSHeapSize: number } }).memory
+                  .usedJSHeapSize || 0) / 1048576
+              ).toFixed(2),
+              total: (
+                ((performance as Performance & { memory: { totalJSHeapSize: number } }).memory
+                  .totalJSHeapSize || 0) / 1048576
+              ).toFixed(2),
+            }
+          : null,
+      });
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [isVisible]);
+
+  if (!isVisible) {
+    return (
+      <button
+        type="button"
+        onClick={() => setIsVisible(true)}
+        style={{
+          position: 'fixed',
+          bottom: 16,
+          right: 16,
+          zIndex: 9999,
+          padding: '6px 12px',
+          background: '#2563eb',
+          color: '#ffffff',
+          border: 'none',
+          borderRadius: 6,
+          cursor: 'pointer',
+          boxShadow: '0 4px 12px rgba(37, 99, 235, 0.4)',
+        }}
+        aria-label="Open performance dashboard"
+      >
+        📊 Perf
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        bottom: 16,
+        right: 16,
+        width: 320,
+        maxHeight: 420,
+        background: '#ffffff',
+        border: '1px solid rgba(15, 23, 42, 0.12)',
+        borderRadius: 8,
+        padding: 12,
+        zIndex: 9999,
+        overflowY: 'auto',
+        fontSize: 12,
+        fontFamily: 'ui-monospace, SFMono-Regular, SFMono, Consolas',
+        boxShadow: '0 10px 30px rgba(15, 23, 42, 0.12)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 8,
+        }}
+      >
+        <h4 style={{ margin: 0, fontSize: 14 }}>Performance Monitor</h4>
+        <button
+          type="button"
+          onClick={() => setIsVisible(false)}
+          aria-label="Close performance dashboard"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: '#64748b',
+            cursor: 'pointer',
+            fontSize: 16,
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <section aria-label="Page metrics" style={{ marginBottom: 12 }}>
+        <strong>Page</strong>
+        <ul style={{ listStyle: 'none', padding: 0, margin: '6px 0 0' }}>
+          <li>Load: {metrics.pageLoad ? `${metrics.pageLoad.toFixed(2)}ms` : '—'}</li>
+          <li>DOM Ready: {metrics.domReady ? `${metrics.domReady.toFixed(2)}ms` : '—'}</li>
+        </ul>
+      </section>
+
+      <section aria-label="Step transitions" style={{ marginBottom: 12 }}>
+        <strong>Step Transitions</strong>
+        {metrics.stepTransitions.length > 0 ? (
+          <ul style={{ listStyle: 'none', padding: 0, margin: '6px 0 0' }}>
+            {metrics.stepTransitions.map((step) => (
+              <li key={step.name}>
+                {step.name}: {step.duration}ms
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p style={{ margin: '6px 0 0', color: '#94a3b8' }}>No measurements yet</p>
+        )}
+      </section>
+
+      <section aria-label="Validation metrics" style={{ marginBottom: 12 }}>
+        <strong>Validations</strong>
+        {metrics.validations.length > 0 ? (
+          <ul style={{ listStyle: 'none', padding: 0, margin: '6px 0 0' }}>
+            {metrics.validations.map((validation) => (
+              <li key={validation.name}>
+                {validation.name}: {validation.duration}ms
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p style={{ margin: '6px 0 0', color: '#94a3b8' }}>No validation metrics yet</p>
+        )}
+      </section>
+
+      <section aria-label="Memory usage">
+        <strong>Memory</strong>
+        {metrics.memory ? (
+          <ul style={{ listStyle: 'none', padding: 0, margin: '6px 0 0' }}>
+            <li>Used: {metrics.memory.used} MB</li>
+            <li>Total: {metrics.memory.total} MB</li>
+          </ul>
+        ) : (
+          <p style={{ margin: '6px 0 0', color: '#94a3b8' }}>Memory metrics unavailable</p>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/packages/form-engine/src/hooks/useFormAnalytics.ts
+++ b/packages/form-engine/src/hooks/useFormAnalytics.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { FormAnalytics } from '../analytics/FormAnalytics';
+import { PerformanceBudget } from '../performance/PerformanceBudget';
+import type { FormAnalyticsConfig, SessionMetrics } from '../types';
+
+const DEFAULT_HOOK_CONFIG: Pick<
+  FormAnalyticsConfig,
+  'enabled' | 'sampling' | 'sensitive' | 'bufferSize' | 'flushInterval'
+> = {
+  enabled: true,
+  sampling: 1,
+  sensitive: true,
+  bufferSize: 10,
+  flushInterval: 5000,
+};
+
+export interface UseFormAnalyticsResult {
+  trackStepView: (stepId: string) => void;
+  trackFieldInteraction: (
+    fieldName: string,
+    value: unknown,
+    eventType: 'focus' | 'blur' | 'change',
+  ) => void;
+  trackValidation: (
+    stepId: string,
+    errors: Record<string, any>,
+    success: boolean,
+    durationMs?: number,
+  ) => void;
+  trackSubmission: (success: boolean, data?: unknown, error?: Error) => void;
+  measureStepTransition: (from: string, to: string) => (() => void) | undefined;
+  startValidationMeasurement: (stepId: string) => (() => void) | undefined;
+  getSessionId: () => string | undefined;
+  getSessionMetrics: () => SessionMetrics | undefined;
+}
+
+export function useFormAnalytics(
+  formId: string,
+  schemaVersion: string,
+  config?: Partial<FormAnalyticsConfig>,
+): UseFormAnalyticsResult {
+  const analyticsRef = useRef<FormAnalytics | null>(null);
+  const performanceBudgetRef = useRef<PerformanceBudget | null>(null);
+  const serializedConfig = useMemo(() => JSON.stringify(config ?? {}), [config]);
+
+  useEffect(() => {
+    const mergedConfig: FormAnalyticsConfig = {
+      ...DEFAULT_HOOK_CONFIG,
+      ...config,
+      enabled: config?.enabled ?? DEFAULT_HOOK_CONFIG.enabled,
+    };
+
+    analyticsRef.current = new FormAnalytics(mergedConfig);
+    performanceBudgetRef.current = new PerformanceBudget(mergedConfig.performanceBudgets);
+
+    analyticsRef.current.trackEvent('form_initialized', { formId, schemaVersion }, 'form', {
+      formId,
+      schemaVersion,
+      sensitive: false,
+    });
+
+    return () => {
+      analyticsRef.current?.destroy();
+      performanceBudgetRef.current?.reset();
+      performanceBudgetRef.current = null;
+    };
+  }, [formId, schemaVersion, serializedConfig]);
+
+  const trackStepView = useCallback(
+    (stepId: string) => {
+      analyticsRef.current?.trackEvent(
+        'step_viewed',
+        { formId, schemaVersion, stepId },
+        'navigation',
+        { formId, schemaVersion, stepId, sensitive: false },
+      );
+    },
+    [formId, schemaVersion],
+  );
+
+  const trackFieldInteraction = useCallback(
+    (fieldName: string, value: unknown, eventType: 'focus' | 'blur' | 'change') => {
+      analyticsRef.current?.trackEvent(
+        `field_${eventType}`,
+        {
+          formId,
+          schemaVersion,
+          fieldName,
+          hasValue: value !== null && value !== undefined && value !== '',
+          valueLength: typeof value === 'string' ? value.length : undefined,
+        },
+        'field',
+        { formId, schemaVersion, fieldName },
+      );
+    },
+    [formId, schemaVersion],
+  );
+
+  const trackValidation = useCallback(
+    (stepId: string, errors: Record<string, any>, success: boolean, durationMs?: number) => {
+      analyticsRef.current?.trackEvent(
+        'validation_attempt',
+        { formId, schemaVersion, stepId },
+        'performance',
+        { formId, schemaVersion, stepId },
+      );
+
+      if (typeof durationMs === 'number') {
+        performanceBudgetRef.current?.checkBudget('validation', durationMs);
+      } else if (typeof performance !== 'undefined') {
+        const entry = performance.getEntriesByName(`validation_${stepId}`).at(-1);
+        if (entry) {
+          performanceBudgetRef.current?.checkBudget('validation', entry.duration);
+        }
+      }
+
+      const eventName = success ? 'validation_success' : 'validation_error';
+      analyticsRef.current?.trackEvent(
+        eventName,
+        {
+          formId,
+          schemaVersion,
+          stepId,
+          errorCount: Object.keys(errors ?? {}).length,
+          errorFields: Object.keys(errors ?? {}),
+        },
+        success ? 'performance' : 'error',
+        { formId, schemaVersion, stepId },
+      );
+    },
+    [formId, schemaVersion],
+  );
+
+  const trackSubmission = useCallback(
+    (success: boolean, data?: unknown, error?: Error) => {
+      const metrics = analyticsRef.current?.getSessionMetrics();
+      const start = metrics?.startTime ?? Date.now();
+      analyticsRef.current?.trackEvent(
+        success ? 'form_submitted' : 'submission_error',
+        {
+          formId,
+          schemaVersion,
+          success,
+          error: error?.message,
+          completionTime: Date.now() - start,
+          payloadSize: data ? JSON.stringify(data).length : undefined,
+        },
+        success ? 'form' : 'error',
+        { formId, schemaVersion },
+      );
+
+      if (success && metrics?.endTime) {
+        performanceBudgetRef.current?.checkBudget(
+          'formCompletion',
+          metrics.endTime - metrics.startTime,
+        );
+      }
+    },
+    [formId, schemaVersion],
+  );
+
+  const measureStepTransition = useCallback(
+    (from: string, to: string) => analyticsRef.current?.measureStepTransition(from, to),
+    [],
+  );
+
+  const startValidationMeasurement = useCallback(
+    (stepId: string) => analyticsRef.current?.measureValidation(stepId),
+    [],
+  );
+
+  const getSessionId = useCallback(() => analyticsRef.current?.getSessionId(), []);
+
+  const getSessionMetrics = useCallback(() => analyticsRef.current?.getSessionMetrics(), []);
+
+  return {
+    trackStepView,
+    trackFieldInteraction,
+    trackValidation,
+    trackSubmission,
+    measureStepTransition,
+    startValidationMeasurement,
+    getSessionId,
+    getSessionMetrics,
+  };
+}

--- a/packages/form-engine/src/index.ts
+++ b/packages/form-engine/src/index.ts
@@ -25,3 +25,5 @@ export * from './performance/PerformanceBudget';
 export * from './hooks/useStepValidation';
 export * from './hooks/useComputedFields';
 export * from './hooks/useDataSource';
+export * from './hooks/useFormAnalytics';
+export * from './components/PerformanceDashboard';

--- a/packages/form-engine/src/performance/PerformanceBudget.ts
+++ b/packages/form-engine/src/performance/PerformanceBudget.ts
@@ -1,32 +1,153 @@
-export interface BudgetCheckResult {
-  name: string;
-  duration: number;
-  limit: number;
-  withinBudget: boolean;
-}
+import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals';
+
+import type { PerformanceBudgets, PerformanceBudgetViolation } from '../types';
+
+type BudgetMetric = keyof PerformanceBudgets | string;
+
+type BudgetUnit = 'ms' | 'bytes' | 'count';
+
+const DEFAULT_BUDGETS: PerformanceBudgets = {
+  stepTransition: 150,
+  validation: 50,
+  initialLoad: 500,
+  bundleSize: 150 * 1024,
+  formCompletion: 5 * 60 * 1000,
+};
 
 export class PerformanceBudget {
-  private budgets: Record<string, number> = {
-    stepTransition: 150,
-    validation: 50,
-    render: 100
-  };
+  private budgets: PerformanceBudgets;
+  private violations: PerformanceBudgetViolation[] = [];
 
-  setBudget(metric: string, limit: number): void {
+  constructor(overrides?: PerformanceBudgets) {
+    this.budgets = {
+      ...DEFAULT_BUDGETS,
+      ...overrides,
+    };
+
+    if (typeof window !== 'undefined') {
+      this.initWebVitalTracking();
+    }
+  }
+
+  setBudget(metric: keyof PerformanceBudgets, limit: number): void {
     this.budgets[metric] = limit;
   }
 
-  check(metric: string, duration: number): BudgetCheckResult {
-    const limit = this.budgets[metric] ?? 0;
-    const withinBudget = limit === 0 ? true : duration <= limit;
-    if (!withinBudget) {
-      console.warn(`Performance budget exceeded for ${metric}: ${duration}ms > ${limit}ms`);
+  checkBudget(
+    metric: BudgetMetric,
+    value: number,
+    unit: BudgetUnit = 'ms',
+    context: Record<string, any> = {},
+  ): boolean {
+    const limit = (this.budgets as Record<string, number | undefined>)[metric];
+    if (limit === undefined || limit <= 0) {
+      return true;
     }
-    return {
-      name: metric,
-      duration,
-      limit,
-      withinBudget
+
+    if (value <= limit) {
+      return true;
+    }
+
+    const violation: PerformanceBudgetViolation = {
+      metric: metric.toString(),
+      actual: unit === 'ms' ? Number(value.toFixed(2)) : value,
+      budget: limit,
+      timestamp: Date.now(),
+      severity: value > limit * 1.2 ? 'critical' : 'warning',
+      context: { ...context, unit },
     };
+
+    this.violations.push(violation);
+
+    console.error(
+      `Performance budget violation for ${violation.metric}: ${violation.actual}${unit} (budget: ${limit}${unit})`,
+      context,
+    );
+
+    this.notifyMonitoringEndpoint(violation);
+
+    return false;
+  }
+
+  getViolations(): PerformanceBudgetViolation[] {
+    return [...this.violations];
+  }
+
+  generateReport(): string {
+    const lines = ['=== Performance Budget Report ===', `Violations: ${this.violations.length}`];
+
+    if (this.violations.length === 0) {
+      lines.push('', '✅ All performance budgets met!');
+      return lines.join('\n');
+    }
+
+    lines.push('', 'Violations:');
+    for (const violation of this.violations) {
+      const unit = violation.context?.unit ?? 'ms';
+      lines.push(
+        `  - ${violation.metric}: ${violation.actual}${unit} (budget: ${violation.budget}${unit})`,
+      );
+    }
+
+    return lines.join('\n');
+  }
+
+  recordBundleSize(bytes: number): void {
+    this.checkBudget('bundleSize', bytes, 'bytes');
+  }
+
+  reset(): void {
+    this.violations = [];
+  }
+
+  private initWebVitalTracking(): void {
+    const handler = (metric: { name: string; value: number }) => {
+      switch (metric.name) {
+        case 'FCP':
+        case 'LCP':
+        case 'TTFB':
+          this.checkBudget('initialLoad', metric.value, 'ms', { metric: metric.name });
+          break;
+        case 'INP':
+          this.checkBudget('stepTransition', metric.value, 'ms', { metric: metric.name });
+          break;
+        case 'CLS':
+          this.checkBudget('validation', metric.value, 'count', { metric: metric.name });
+          break;
+        default:
+          break;
+      }
+    };
+
+    try {
+      onCLS(handler);
+      onINP(handler);
+      onLCP(handler);
+      onFCP(handler);
+      onTTFB(handler);
+    } catch (error) {
+      console.warn('Unable to initialize web-vitals monitoring', error);
+    }
+  }
+
+  private notifyMonitoringEndpoint(violation: PerformanceBudgetViolation): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const endpoint = (window as typeof window & { MONITORING_ENDPOINT?: string })
+      .MONITORING_ENDPOINT;
+    if (!endpoint || typeof fetch === 'undefined') {
+      return;
+    }
+
+    fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(violation),
+      keepalive: true,
+    }).catch((error) => {
+      console.warn('Failed to report performance budget violation', error);
+    });
   }
 }

--- a/packages/form-engine/src/types/analytics.types.ts
+++ b/packages/form-engine/src/types/analytics.types.ts
@@ -1,0 +1,56 @@
+export interface AnalyticsEvent {
+  name: string;
+  category?: 'form' | 'field' | 'navigation' | 'performance' | 'error';
+  data: Record<string, any>;
+  timestamp: number;
+  sessionId: string;
+  formId?: string;
+  schemaVersion?: string;
+  stepId?: string;
+  fieldName?: string;
+}
+
+export interface PerformanceMetric {
+  name: string;
+  value: number;
+  unit: 'ms' | 'bytes' | 'count';
+  timestamp: number;
+  metadata?: Record<string, any>;
+}
+
+export interface FormAnalyticsConfig {
+  enabled: boolean;
+  endpoint?: string;
+  sampling?: number;
+  sensitive?: boolean;
+  bufferSize?: number;
+  flushInterval?: number;
+  performanceBudgets?: PerformanceBudgets;
+}
+
+export interface PerformanceBudgets {
+  stepTransition?: number;
+  validation?: number;
+  initialLoad?: number;
+  bundleSize?: number;
+  formCompletion?: number;
+}
+
+export interface SessionMetrics {
+  startTime: number;
+  endTime?: number;
+  completedSteps: string[];
+  errors: number;
+  validationAttempts: number;
+  fieldInteractions: number;
+  abandonedAt?: string;
+}
+
+export interface PerformanceBudgetViolation {
+  metric: string;
+  actual: number;
+  budget: number;
+  timestamp: number;
+  severity: 'warning' | 'critical';
+  context?: Record<string, any>;
+}

--- a/packages/form-engine/src/types/index.ts
+++ b/packages/form-engine/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './rules.types';
 export * from './ui.types';
 export * from './computed.types';
 export * from './events';
+export * from './analytics.types';

--- a/packages/form-engine/tests/unit/analytics/FormAnalytics.test.ts
+++ b/packages/form-engine/tests/unit/analytics/FormAnalytics.test.ts
@@ -1,0 +1,95 @@
+import { performance as nodePerformance } from 'perf_hooks';
+
+import { FormAnalytics } from '../../../src/analytics/FormAnalytics';
+import type { FormAnalyticsConfig } from '../../../src/types';
+
+const perf = globalThis.performance as Performance | undefined;
+if (!perf || typeof perf.mark !== 'function') {
+  Object.defineProperty(globalThis, 'performance', {
+    configurable: true,
+    value: nodePerformance as unknown as Performance,
+  });
+}
+
+describe('FormAnalytics', () => {
+  let analytics: FormAnalytics | null;
+
+  const createConfig = (overrides: Partial<FormAnalyticsConfig> = {}): FormAnalyticsConfig => ({
+    enabled: true,
+    sampling: 1,
+    sensitive: true,
+    bufferSize: 50,
+    flushInterval: 0,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    if (typeof performance.clearMarks === 'function') {
+      performance.clearMarks();
+    }
+    if (typeof performance.clearMeasures === 'function') {
+      performance.clearMeasures();
+    }
+    analytics = new FormAnalytics(createConfig());
+  });
+
+  afterEach(() => {
+    analytics?.destroy();
+    analytics = null;
+    jest.restoreAllMocks();
+  });
+
+  it('sanitizes sensitive field values when tracking events', () => {
+    analytics?.trackEvent('form_data', {
+      name: 'John Doe',
+      email: 'john@example.com',
+      phone: '555-1234',
+    });
+
+    const events = (
+      analytics as unknown as { events: Array<{ name: string; data: Record<string, unknown> }> }
+    )?.events;
+    const event = events?.find((entry) => entry.name === 'form_data');
+    expect(event).toBeDefined();
+    expect(event?.data.email).toBe('[REDACTED]');
+    expect(event?.data.phone).toBe('[REDACTED]');
+    expect(event?.data.name).toBe('John Doe');
+  });
+
+  it('honors sampling rate when recording events', () => {
+    analytics?.destroy();
+    const randomSpy = jest.spyOn(Math, 'random');
+    analytics = new FormAnalytics(createConfig({ sampling: 0.5 }));
+
+    randomSpy.mockReturnValue(0.3);
+    analytics?.trackEvent('sampled_event');
+
+    randomSpy.mockReturnValue(0.8);
+    analytics?.trackEvent('skipped_event');
+
+    const events = (analytics as unknown as { events: Array<{ name: string }> })?.events ?? [];
+    const names = events.map((event) => event.name);
+    expect(names).toContain('sampled_event');
+    expect(names).not.toContain('skipped_event');
+  });
+
+  it('creates performance marks for step transitions', () => {
+    const measure = analytics?.measureStepTransition('step1', 'step2');
+    expect(typeof measure).toBe('function');
+
+    if (!measure) {
+      return;
+    }
+
+    const start = performance.now();
+    while (performance.now() - start < 5) {
+      // busy wait to create measurable duration
+    }
+
+    measure();
+
+    const entries = performance.getEntriesByName('step_step1_to_step2');
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[entries.length - 1]?.duration ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/packages/form-engine/tests/unit/performance/PerformanceBudget.test.ts
+++ b/packages/form-engine/tests/unit/performance/PerformanceBudget.test.ts
@@ -1,0 +1,56 @@
+jest.mock('web-vitals', () => ({
+  onCLS: jest.fn(),
+  onFCP: jest.fn(),
+  onINP: jest.fn(),
+  onLCP: jest.fn(),
+  onTTFB: jest.fn(),
+}));
+
+import { PerformanceBudget } from '../../../src/performance/PerformanceBudget';
+
+describe('PerformanceBudget', () => {
+  let budget: PerformanceBudget;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    budget = new PerformanceBudget({
+      stepTransition: 100,
+      validation: 30,
+    });
+  });
+
+  it('detects budget violations', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined as unknown as void);
+
+    const passed = budget.checkBudget('stepTransition', 150);
+
+    expect(passed).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Performance budget violation'),
+      expect.any(Object),
+    );
+  });
+
+  it('tracks violations for reporting', () => {
+    budget.setBudget('validation', 30);
+    budget.checkBudget('validation', 50);
+    budget.checkBudget('stepTransition', 200);
+
+    const violations = budget.getViolations();
+    expect(violations).toHaveLength(2);
+    expect(violations[0].metric).toBe('validation');
+    expect(violations[1].metric).toBe('stepTransition');
+  });
+
+  it('generates human readable report', () => {
+    budget.setBudget('validation', 30);
+    budget.checkBudget('validation', 50);
+
+    const report = budget.generateReport();
+    expect(report).toContain('Performance Budget Report');
+    expect(report).toContain('Violations: 1');
+    expect(report).toContain('validation: 50ms (budget: 30ms)');
+  });
+});


### PR DESCRIPTION
## Summary
- expand the form engine analytics model with dedicated types, richer session tracking, batching, and performance observer integrations
- expose a composable `useFormAnalytics` hook and on-page performance dashboard for collecting and viewing live metrics
- add web vitals performance budgeting with automated tests covering analytics sanitisation, sampling, and budget violations

## Checklist
- [x] Implemented requirements from `docs/form-builder/step-09-performance-analytics.md`
- [x] Added/updated tests (Jest/RTL)
- [x] Code formatted with Prettier
- [x] CI passing (lint + typecheck + tests + build + size)

## CI
- ✅ `npm run lint`
- ✅ `npm run typecheck`
- ✅ `npm test`
- ✅ `npm run build`
- ✅ `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_68cc74a31614832aaec09dd474b249f0