### PR TITLE
feat(migration): add migration tooling (step 10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@babel/parser": "^7.26.2",
+        "@babel/traverse": "^7.25.9",
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.4",
@@ -72,7 +74,8 @@
         "vaul": "^0.9.6",
         "web-vitals": "^5.1.0",
         "xstate": "^5.5.0",
-        "zod": "latest"
+        "zod": "latest",
+        "zod-to-json-schema": "^3.23.3"
       },
       "devDependencies": {
         "@netlify/functions": "^3.0.4",
@@ -80,6 +83,7 @@
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.2",
+        "@types/babel__traverse": "^7.20.6",
         "@types/crypto-js": "^4.2.2",
         "@types/jest": "^29.5.12",
         "@types/jsonpath": "^0.2.4",
@@ -124,7 +128,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -204,7 +207,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
       "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
@@ -221,7 +223,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
       "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -279,7 +280,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -329,7 +329,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -337,7 +336,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.27.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -385,7 +383,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
       "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.4"
@@ -401,7 +398,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
       "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -661,7 +657,6 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -676,7 +671,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
       "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -695,7 +689,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
       "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -707,7 +700,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.27.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2023,16 +2015,6 @@
       },
       "engines": {
         "node": ">=18.14.0"
-      }
-    },
-    "node_modules/@netlify/zip-it-and-ship-it/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@next/env": {
@@ -7351,7 +7333,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -12264,7 +12245,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -13001,7 +12981,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -25253,14 +25232,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/netlify-cli/node_modules/zod": {
-      "version": "3.24.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/netlify/node_modules/node-fetch": {
       "version": "3.3.2",
       "dev": true,
@@ -29435,12 +29406,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.9.tgz",
-      "integrity": "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:form-engine": "tsc -p packages/form-engine/tsconfig.json"
   },
   "dependencies": {
+    "@babel/parser": "^7.26.2",
+    "@babel/traverse": "^7.25.9",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.4",
@@ -80,9 +82,11 @@
     "vaul": "^0.9.6",
     "web-vitals": "^5.1.0",
     "xstate": "^5.5.0",
-    "zod": "latest"
+    "zod": "latest",
+    "zod-to-json-schema": "^3.23.3"
   },
   "devDependencies": {
+    "@types/babel__traverse": "^7.20.6",
     "@netlify/functions": "^3.0.4",
     "@size-limit/file": "^11.1.4",
     "@testing-library/jest-dom": "^6.2.0",

--- a/packages/form-engine/src/index.ts
+++ b/packages/form-engine/src/index.ts
@@ -27,3 +27,6 @@ export * from './hooks/useComputedFields';
 export * from './hooks/useDataSource';
 export * from './hooks/useFormAnalytics';
 export * from './components/PerformanceDashboard';
+export * from './migration/ZodMigrator';
+export * from './migration/ReactFormMigrator';
+export * from './testing/PathGenerator';

--- a/packages/form-engine/src/migration/ReactFormMigrator.ts
+++ b/packages/form-engine/src/migration/ReactFormMigrator.ts
@@ -1,0 +1,403 @@
+import * as parser from '@babel/parser';
+import traverse from '@babel/traverse';
+
+import type {
+  MigrationConfig,
+  MigrationError,
+  MigrationResult,
+  MigrationStats,
+  MigrationWarning,
+  UnifiedFormSchema,
+  JSONSchema,
+} from '../types';
+
+interface ExtractedField {
+  name: string;
+  type?: string;
+  label?: string;
+  placeholder?: string;
+  required?: boolean;
+  options?: Array<{ label: string; value: string | number }>;
+}
+
+interface FormStructure {
+  fields: ExtractedField[];
+  validations: Array<{ field: string; rule: string }>;
+  handlers: string[];
+  warnings: MigrationWarning[];
+}
+
+export class ReactFormMigrator {
+  async migrateComponent(
+    componentCode: string,
+    options?: MigrationConfig['options'],
+  ): Promise<MigrationResult> {
+    try {
+      const ast = parser.parse(componentCode, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      const structure = this.extractFormStructure(ast);
+      const schema = this.buildSchemaFromStructure(structure);
+
+      if (options?.validateOutput && schema) {
+        // The Zod migrator handles full schema validation. For React migrations we return warnings instead
+        // to encourage manual review without failing the migration outright.
+        if (schema.steps.length === 0) {
+          structure.warnings.push({
+            type: 'empty_schema',
+            message: 'No form fields detected in the component',
+            suggestion: 'Confirm that the component renders input elements directly.',
+          });
+        }
+      }
+
+      return {
+        success: true,
+        schema,
+        errors: [],
+        warnings: structure.warnings,
+        stats: this.calculateStats(structure),
+      };
+    } catch (error) {
+      const migrationError: MigrationError = {
+        type: 'parse',
+        message: error instanceof Error ? error.message : 'Failed to parse React component',
+      };
+
+      return {
+        success: false,
+        errors: [migrationError],
+        warnings: [],
+        stats: {
+          fieldsConverted: 0,
+          validationsConverted: 0,
+          customLogicDetected: 0,
+          conversionAccuracy: 0,
+          estimatedEffort: 'high',
+        },
+      };
+    }
+  }
+
+  private extractFormStructure(ast: parser.ParseResult<any>): FormStructure {
+    const structure: FormStructure = {
+      fields: [],
+      validations: [],
+      handlers: [],
+      warnings: [],
+    };
+
+    traverse(ast, {
+      JSXElement: (path) => {
+        const element = path.node;
+        const nameNode = element.openingElement.name;
+        const tagName = this.getTagName(nameNode);
+
+        if (!tagName) {
+          return;
+        }
+
+        if (this.isFormField(tagName)) {
+          const field = this.extractFieldInfo(element);
+          if (!field.name) {
+            const generatedName = `field_${structure.fields.length + 1}`;
+            structure.warnings.push({
+              type: 'missing_name',
+              message: `Detected <${tagName}> without a name attribute. Generated identifier ${generatedName}.`,
+            });
+            field.name = generatedName;
+          }
+
+          structure.fields.push(field);
+        }
+      },
+      CallExpression: (path) => {
+        const callee = path.node.callee;
+        if (this.isRegisterCall(callee) && path.node.arguments.length > 0) {
+          const [firstArg, secondArg] = path.node.arguments;
+          if (firstArg.type === 'StringLiteral') {
+            structure.validations.push({ field: firstArg.value, rule: 'register' });
+          }
+
+          if (secondArg && secondArg.type === 'ObjectExpression') {
+            const requiredProp = secondArg.properties.find(
+              (prop) =>
+                prop.type === 'ObjectProperty' &&
+                prop.key.type === 'Identifier' &&
+                prop.key.name === 'required',
+            );
+
+            if (requiredProp && requiredProp.type === 'ObjectProperty') {
+              const fieldName = firstArg.type === 'StringLiteral' ? firstArg.value : 'unknown';
+              structure.validations.push({ field: fieldName, rule: 'required' });
+            }
+          }
+        }
+      },
+    });
+
+    return structure;
+  }
+
+  private getTagName(node: any): string | null {
+    if (!node) return null;
+
+    if (node.type === 'JSXIdentifier') {
+      return node.name;
+    }
+
+    if (node.type === 'JSXMemberExpression') {
+      return this.getTagName(node.property);
+    }
+
+    return null;
+  }
+
+  private isFormField(tagName: string): boolean {
+    const normalised = tagName.toLowerCase();
+    return ['input', 'select', 'textarea'].includes(normalised);
+  }
+
+  private extractFieldInfo(element: any): ExtractedField {
+    const attributes = element.openingElement.attributes ?? [];
+    const field: ExtractedField = { name: '', type: 'text' };
+
+    attributes.forEach((attr: any) => {
+      if (attr.type !== 'JSXAttribute' || !attr.name) {
+        return;
+      }
+
+      const key = attr.name.name;
+      const value = this.extractAttributeValue(attr.value);
+
+      switch (key) {
+        case 'name':
+          field.name = typeof value === 'string' ? value : '';
+          break;
+        case 'type':
+          field.type = typeof value === 'string' ? value : field.type;
+          break;
+        case 'label':
+        case 'aria-label':
+          field.label = typeof value === 'string' ? value : field.label;
+          break;
+        case 'placeholder':
+          field.placeholder = typeof value === 'string' ? value : field.placeholder;
+          break;
+        case 'required':
+          field.required = value !== false;
+          break;
+        case 'options':
+          if (Array.isArray(value)) {
+            field.options = value as ExtractedField['options'];
+          }
+          break;
+        default:
+          break;
+      }
+    });
+
+    return field;
+  }
+
+  private extractAttributeValue(value: any): any {
+    if (!value) {
+      return true;
+    }
+
+    switch (value.type) {
+      case 'StringLiteral':
+        return value.value;
+      case 'BooleanLiteral':
+        return value.value;
+      case 'NumericLiteral':
+        return value.value;
+      case 'ArrayExpression':
+        return value.elements
+          .map((element: any) =>
+            element && element.type === 'ObjectExpression'
+              ? this.transformOptionObject(element)
+              : null,
+          )
+          .filter(Boolean);
+      case 'JSXExpressionContainer':
+        return this.extractExpressionValue(value.expression);
+      default:
+        return null;
+    }
+  }
+
+  private transformOptionObject(node: any): { label: string; value: string | number } | null {
+    const option: { label?: string; value?: string | number } = {};
+
+    node.properties.forEach((prop: any) => {
+      if (prop.type !== 'ObjectProperty') return;
+      const keyName = prop.key.type === 'Identifier' ? prop.key.name : null;
+      if (!keyName) return;
+
+      if (prop.value.type === 'StringLiteral' || prop.value.type === 'NumericLiteral') {
+        option[keyName as 'label' | 'value'] = prop.value.value;
+      }
+    });
+
+    if (option.label === undefined || option.value === undefined) {
+      return null;
+    }
+
+    return { label: String(option.label), value: option.value };
+  }
+
+  private extractExpressionValue(expression: any): any {
+    switch (expression.type) {
+      case 'StringLiteral':
+      case 'NumericLiteral':
+      case 'BooleanLiteral':
+        return expression.value;
+      case 'Identifier':
+        return `{${expression.name}}`;
+      case 'MemberExpression':
+        if (expression.object && expression.property) {
+          const objectName = expression.object.name ?? 'object';
+          const propertyName = expression.property.name ?? 'value';
+          return `{${objectName}.${propertyName}}`;
+        }
+        return null;
+      default:
+        return 'dynamic';
+    }
+  }
+
+  private isRegisterCall(callee: any): boolean {
+    if (!callee) return false;
+
+    if (callee.type === 'Identifier' && callee.name === 'register') {
+      return true;
+    }
+
+    if (callee.type === 'MemberExpression' && callee.property?.type === 'Identifier') {
+      return callee.property.name === 'register';
+    }
+
+    return false;
+  }
+
+  private buildSchemaFromStructure(structure: FormStructure): UnifiedFormSchema {
+    const stepSchema: JSONSchema = { type: 'object', properties: {}, required: [] };
+    const widgets: Record<string, any> = {};
+
+    structure.fields.forEach((field) => {
+      const fieldSchema = this.inferFieldSchema(field);
+      stepSchema.properties![field.name] = fieldSchema;
+
+      if (field.required || this.hasRequiredValidation(structure, field.name)) {
+        stepSchema.required!.push(field.name);
+      }
+
+      widgets[field.name] = this.inferWidgetConfig(field);
+    });
+
+    if (stepSchema.required && stepSchema.required.length === 0) {
+      delete stepSchema.required;
+    }
+
+    return {
+      $id: `react-migrated-${Date.now()}`,
+      version: '1.0.0',
+      metadata: {
+        title: 'Migrated React Form',
+        description: 'Generated from React component analysis',
+        sensitivity: 'low',
+      },
+      steps:
+        stepSchema.properties && Object.keys(stepSchema.properties).length > 0
+          ? [
+              {
+                id: 'step-1',
+                title: 'Form',
+                schema: stepSchema,
+              },
+            ]
+          : [],
+      transitions: [],
+      ui: { widgets },
+    };
+  }
+
+  private inferFieldSchema(field: ExtractedField): JSONSchema {
+    switch (field.type) {
+      case 'number':
+      case 'range':
+        return { type: 'number' };
+      case 'checkbox':
+        return { type: 'boolean' };
+      case 'select':
+        return {
+          type: 'string',
+          enum: field.options?.map((option) => option.value),
+        };
+      case 'email':
+        return { type: 'string', format: 'email' };
+      case 'date':
+        return { type: 'string', format: 'date' };
+      default:
+        return { type: 'string' };
+    }
+  }
+
+  private inferWidgetConfig(field: ExtractedField) {
+    const label = field.label ?? this.toLabel(field.name);
+    const widgetBase = { label };
+
+    switch (field.type) {
+      case 'number':
+      case 'range':
+        return { ...widgetBase, component: 'Number' as const, placeholder: field.placeholder };
+      case 'checkbox':
+        return { ...widgetBase, component: 'Checkbox' as const };
+      case 'select':
+        return {
+          ...widgetBase,
+          component: 'Select' as const,
+          options: field.options,
+        };
+      case 'email':
+        return { ...widgetBase, component: 'Email' as const, placeholder: field.placeholder };
+      default:
+        return { ...widgetBase, component: 'Text' as const, placeholder: field.placeholder };
+    }
+  }
+
+  private hasRequiredValidation(structure: FormStructure, fieldName: string): boolean {
+    return structure.validations.some(
+      (validation) => validation.field === fieldName && validation.rule === 'required',
+    );
+  }
+
+  private toLabel(name: string): string {
+    return name
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/[_-]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .replace(/^./, (char) => char.toUpperCase())
+      .trim();
+  }
+
+  private calculateStats(structure: FormStructure): MigrationStats {
+    const validationsConverted = structure.validations.filter(
+      (validation) => validation.rule === 'required',
+    ).length;
+
+    const effort: MigrationStats['estimatedEffort'] =
+      structure.warnings.length > 3 ? 'medium' : 'low';
+
+    return {
+      fieldsConverted: structure.fields.length,
+      validationsConverted,
+      customLogicDetected: structure.handlers.length,
+      conversionAccuracy: structure.fields.length === 0 ? 0 : 80,
+      estimatedEffort: effort,
+    };
+  }
+}

--- a/packages/form-engine/src/migration/ZodMigrator.ts
+++ b/packages/form-engine/src/migration/ZodMigrator.ts
@@ -1,0 +1,540 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import type {
+  FieldMapping,
+  MigrationConfig,
+  MigrationError,
+  MigrationResult,
+  MigrationStats,
+  MigrationWarning,
+  UnifiedFormSchema,
+  JSONSchema,
+} from '../types';
+import { SchemaValidator } from '../utils/schema-validator';
+
+interface FieldAnalysis {
+  path: string;
+  type: string;
+  optional: boolean;
+  validations?: Record<string, unknown>;
+  values?: unknown[];
+  items?: FieldAnalysis;
+}
+
+interface SchemaAnalysis {
+  fields: FieldAnalysis[];
+}
+
+export class ZodMigrator {
+  private warnings: MigrationWarning[] = [];
+  private errors: MigrationError[] = [];
+  private fieldMappings: FieldMapping[] = [];
+  private generatedTests?: string;
+
+  async migrate(
+    zodSchema: z.ZodSchema<any>,
+    options?: MigrationConfig['options'],
+  ): Promise<MigrationResult> {
+    this.reset();
+
+    try {
+      const jsonSchema = zodToJsonSchema(zodSchema, {
+        target: 'openApi3',
+        $refStrategy: 'none',
+      }) as JSONSchema;
+
+      const formStructure = this.analyzeZodSchema(zodSchema);
+      const unifiedSchema = this.buildUnifiedSchema(jsonSchema, formStructure);
+
+      if (options?.validateOutput) {
+        await this.validateSchema(unifiedSchema);
+      }
+
+      if (options?.generateTests) {
+        this.generatedTests = this.generateMigrationTests(unifiedSchema);
+      }
+
+      return {
+        success: this.errors.length === 0,
+        schema: unifiedSchema,
+        errors: [...this.errors],
+        warnings: [...this.warnings],
+        stats: this.calculateStats(),
+        generatedTests: this.generatedTests,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Migration failed due to an unknown error';
+
+      this.errors.push({
+        type: 'unknown',
+        message,
+      });
+
+      return {
+        success: false,
+        errors: [...this.errors],
+        warnings: [...this.warnings],
+        stats: this.calculateStats(),
+      };
+    }
+  }
+
+  private analyzeZodSchema(schema: z.ZodSchema<any>): SchemaAnalysis {
+    const analysis: SchemaAnalysis = { fields: [] };
+
+    const describe = (current: z.ZodTypeAny, path: string[], inheritedOptional: boolean): void => {
+      const { inner, optional } = this.unwrapType(current);
+      const mergedOptional = inheritedOptional || optional;
+      const typeName = inner._def?.typeName ?? '';
+
+      switch (typeName) {
+        case z.ZodFirstPartyTypeKind.ZodObject: {
+          const shape = (inner as z.ZodObject<any>)._def.shape();
+          Object.entries(shape).forEach(([key, value]) => {
+            describe(value as z.ZodTypeAny, [...path, key], mergedOptional);
+          });
+          break;
+        }
+        case z.ZodFirstPartyTypeKind.ZodArray: {
+          const arrayType = inner as z.ZodArray<any>;
+          const itemAnalysis = this.describeArrayItem(arrayType.element, [...path, '[*]']);
+
+          analysis.fields.push({
+            path: path.join('.'),
+            type: 'array',
+            optional: mergedOptional,
+            items: itemAnalysis,
+          });
+          break;
+        }
+        case z.ZodFirstPartyTypeKind.ZodString: {
+          analysis.fields.push({
+            path: path.join('.'),
+            type: 'string',
+            optional: mergedOptional,
+            validations: this.extractStringValidations(inner as z.ZodString),
+          });
+          break;
+        }
+        case z.ZodFirstPartyTypeKind.ZodNumber: {
+          analysis.fields.push({
+            path: path.join('.'),
+            type: 'number',
+            optional: mergedOptional,
+            validations: this.extractNumberValidations(inner as z.ZodNumber),
+          });
+          break;
+        }
+        case z.ZodFirstPartyTypeKind.ZodBoolean: {
+          analysis.fields.push({
+            path: path.join('.'),
+            type: 'boolean',
+            optional: mergedOptional,
+          });
+          break;
+        }
+        case z.ZodFirstPartyTypeKind.ZodEnum: {
+          const enumDef = inner as z.ZodEnum<any>;
+          analysis.fields.push({
+            path: path.join('.'),
+            type: 'enum',
+            optional: mergedOptional,
+            values: [...enumDef._def.values],
+          });
+          break;
+        }
+        default: {
+          this.warnings.push({
+            type: 'unsupported_type',
+            message: `Unsupported Zod type encountered at ${path.join('.') || 'root'} (${typeName})`,
+            suggestion: 'Consider handling this field manually after migration',
+          });
+          break;
+        }
+      }
+    };
+
+    describe(schema, [], false);
+
+    return analysis;
+  }
+
+  private describeArrayItem(type: z.ZodTypeAny, path: string[]): FieldAnalysis | undefined {
+    const { inner } = this.unwrapType(type);
+    const typeName = inner._def?.typeName ?? '';
+
+    switch (typeName) {
+      case z.ZodFirstPartyTypeKind.ZodString:
+        return {
+          path: path.join('.'),
+          type: 'string',
+          optional: false,
+          validations: this.extractStringValidations(inner as z.ZodString),
+        };
+      case z.ZodFirstPartyTypeKind.ZodNumber:
+        return {
+          path: path.join('.'),
+          type: 'number',
+          optional: false,
+          validations: this.extractNumberValidations(inner as z.ZodNumber),
+        };
+      case z.ZodFirstPartyTypeKind.ZodBoolean:
+        return {
+          path: path.join('.'),
+          type: 'boolean',
+          optional: false,
+        };
+      case z.ZodFirstPartyTypeKind.ZodEnum: {
+        const enumDef = inner as z.ZodEnum<any>;
+        return {
+          path: path.join('.'),
+          type: 'enum',
+          optional: false,
+          values: [...enumDef._def.values],
+        };
+      }
+      default:
+        this.warnings.push({
+          type: 'array_item',
+          message: `Array item at ${path.join('.')} defaults to string representation`,
+          suggestion: 'Review array items and adjust the generated schema manually if required',
+        });
+        return {
+          path: path.join('.'),
+          type: 'string',
+          optional: false,
+        };
+    }
+  }
+
+  private unwrapType(type: z.ZodTypeAny): { inner: z.ZodTypeAny; optional: boolean } {
+    let optional = false;
+    let current: z.ZodTypeAny = type;
+
+    while (true) {
+      if (current instanceof z.ZodOptional || current instanceof z.ZodNullable) {
+        optional = true;
+        current = current._def.innerType;
+        continue;
+      }
+
+      if (current instanceof z.ZodDefault) {
+        current = current._def.innerType;
+        continue;
+      }
+
+      if (current instanceof z.ZodEffects) {
+        current = current._def.schema;
+        continue;
+      }
+
+      break;
+    }
+
+    return { inner: current, optional };
+  }
+
+  private extractStringValidations(zodString: z.ZodString): Record<string, unknown> {
+    const validations: Record<string, unknown> = {};
+    const checks = (zodString as any)._def?.checks ?? [];
+
+    for (const check of checks) {
+      switch (check.kind) {
+        case 'min':
+          validations.minLength = check.value;
+          break;
+        case 'max':
+          validations.maxLength = check.value;
+          break;
+        case 'email':
+          validations.format = 'email';
+          break;
+        case 'url':
+          validations.format = 'uri';
+          break;
+        case 'regex':
+          validations.pattern = check.regex?.source;
+          break;
+        case 'uuid':
+          validations.format = 'uuid';
+          break;
+        default:
+          break;
+      }
+    }
+
+    return validations;
+  }
+
+  private extractNumberValidations(zodNumber: z.ZodNumber): Record<string, unknown> {
+    const validations: Record<string, unknown> = {};
+    const checks = (zodNumber as any)._def?.checks ?? [];
+
+    for (const check of checks) {
+      switch (check.kind) {
+        case 'min':
+          if (check.inclusive === false) {
+            validations.exclusiveMinimum = check.value;
+          } else {
+            validations.minimum = check.value;
+          }
+          break;
+        case 'max':
+          if (check.inclusive === false) {
+            validations.exclusiveMaximum = check.value;
+          } else {
+            validations.maximum = check.value;
+          }
+          break;
+        case 'int':
+          validations.multipleOf = 1;
+          break;
+        case 'multipleOf':
+          validations.multipleOf = check.value;
+          break;
+        default:
+          break;
+      }
+    }
+
+    return validations;
+  }
+
+  private buildUnifiedSchema(jsonSchema: JSONSchema, analysis: SchemaAnalysis): UnifiedFormSchema {
+    const schema: UnifiedFormSchema = {
+      $id: `migrated-${Date.now()}`,
+      version: '1.0.0',
+      metadata: {
+        title: 'Migrated Form',
+        description: 'Form migrated from an existing schema definition',
+        sensitivity: 'low',
+      },
+      definitions: jsonSchema.definitions ?? jsonSchema.$defs ?? {},
+      steps: [],
+      transitions: [],
+      ui: { widgets: {} },
+    };
+
+    const groupedFields = this.groupFieldsIntoSteps(analysis.fields);
+
+    groupedFields.forEach((fields, index) => {
+      const stepId = `step-${index + 1}`;
+      const stepSchema: JSONSchema = { type: 'object', properties: {}, required: [] };
+
+      fields.forEach((field) => {
+        const fieldKey = field.path.split('.').pop() ?? `field_${index}`;
+        const json = this.convertFieldToJsonSchema(field);
+        stepSchema.properties![fieldKey] = json;
+        if (!field.optional) {
+          stepSchema.required!.push(fieldKey);
+        }
+
+        const widget = this.inferUIWidget(field, fieldKey);
+
+        this.fieldMappings.push({
+          source: field.path,
+          target: `${stepId}.${fieldKey}`,
+          validation: json,
+          ui: widget,
+        });
+
+        schema.ui.widgets[fieldKey] = widget;
+      });
+
+      if (stepSchema.required && stepSchema.required.length === 0) {
+        delete stepSchema.required;
+      }
+
+      schema.steps.push({
+        id: stepId,
+        title: this.generateStepTitle(fields, index),
+        schema: stepSchema,
+      });
+
+      const nextStep = groupedFields[index + 1];
+      if (nextStep) {
+        schema.transitions.push({ from: stepId, to: `step-${index + 2}`, default: true });
+      }
+    });
+
+    return schema;
+  }
+
+  private groupFieldsIntoSteps(fields: FieldAnalysis[]): FieldAnalysis[][] {
+    if (fields.length === 0) {
+      return [[]];
+    }
+
+    if (fields.length <= 8) {
+      return [fields];
+    }
+
+    const groups: FieldAnalysis[][] = [];
+    for (let i = 0; i < fields.length; i += 8) {
+      groups.push(fields.slice(i, i + 8));
+    }
+    return groups;
+  }
+
+  private convertFieldToJsonSchema(field: FieldAnalysis): JSONSchema {
+    switch (field.type) {
+      case 'number':
+        return {
+          type: 'number',
+          ...field.validations,
+        };
+      case 'boolean':
+        return { type: 'boolean' };
+      case 'enum':
+        return {
+          type: 'string',
+          enum: field.values,
+        };
+      case 'array':
+        return {
+          type: 'array',
+          items: field.items ? this.convertFieldToJsonSchema(field.items) : {},
+        };
+      case 'string':
+      default:
+        return {
+          type: 'string',
+          ...field.validations,
+        };
+    }
+  }
+
+  private inferUIWidget(field: FieldAnalysis, fieldKey: string) {
+    const widgetBase = {
+      component: 'Text' as const,
+      label: this.prettyLabel(fieldKey),
+    };
+
+    switch (field.type) {
+      case 'number':
+        return { ...widgetBase, component: 'Number' as const };
+      case 'boolean':
+        return { ...widgetBase, component: 'Checkbox' as const };
+      case 'enum':
+        return {
+          ...widgetBase,
+          component: 'Select' as const,
+          options: field.values?.map((value) => ({
+            label: String(value),
+            value: typeof value === 'number' ? value : String(value),
+          })),
+        };
+      default:
+        if (field.validations?.format === 'email') {
+          return { ...widgetBase, component: 'Email' as const };
+        }
+        return widgetBase;
+    }
+  }
+
+  private prettyLabel(fieldKey: string): string {
+    return fieldKey
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/[_-]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .replace(/^./, (char) => char.toUpperCase())
+      .trim();
+  }
+
+  private generateStepTitle(fields: FieldAnalysis[], index: number): string {
+    if (fields.length === 0) {
+      return `Step ${index + 1}`;
+    }
+
+    const hint = fields[0].path.toLowerCase();
+    if (hint.includes('employment')) {
+      return 'Employment Details';
+    }
+    if (hint.includes('address')) {
+      return 'Address Information';
+    }
+    if (hint.includes('contact') || hint.includes('email')) {
+      return 'Contact Details';
+    }
+    return `Step ${index + 1}`;
+  }
+
+  private async validateSchema(schema: UnifiedFormSchema): Promise<void> {
+    const validator = new SchemaValidator();
+    const validation = validator.validateSchema(schema);
+
+    if (!validation.valid) {
+      validation.errors.forEach((error) => {
+        this.errors.push({
+          type: 'validation',
+          message: error.message,
+          location: {
+            file: schema.$id,
+          },
+          suggestion:
+            'Adjust the generated schema or update the source definition before rerunning the migration.',
+        });
+      });
+
+      throw new Error('Generated schema failed validation');
+    }
+  }
+
+  private generateMigrationTests(schema: UnifiedFormSchema): string {
+    const lines: string[] = [];
+    lines.push(`describe('Migrated Form: ${schema.metadata.title}', () => {`);
+    lines.push(`  it('includes ${schema.steps.length} steps', () => {`);
+    lines.push('    expect(schema.steps).toHaveLength(' + schema.steps.length + ');');
+    lines.push('  });');
+    lines.push('');
+    lines.push("  it('defines transitions that link all steps', () => {");
+    lines.push('    const stepIds = new Set(schema.steps.map((step) => step.id));');
+    lines.push('    schema.transitions.forEach((transition) => {');
+    lines.push('      expect(stepIds.has(transition.from)).toBe(true);');
+    lines.push('      expect(stepIds.has(transition.to)).toBe(true);');
+    lines.push('    });');
+    lines.push('  });');
+    lines.push('});');
+    return lines.join('\n');
+  }
+
+  private calculateStats(): MigrationStats {
+    const validationsConverted = this.fieldMappings.filter((mapping) => {
+      if (!mapping.validation) {
+        return false;
+      }
+
+      if (typeof mapping.validation !== 'object') {
+        return false;
+      }
+
+      return Object.keys(mapping.validation as Record<string, unknown>).length > 0;
+    }).length;
+
+    const conversionAccuracy = Math.max(
+      0,
+      Math.min(100, 100 - this.errors.length * 10 + this.warnings.length * -2),
+    );
+
+    const estimatedEffort: MigrationStats['estimatedEffort'] =
+      this.errors.length > 0 ? 'high' : this.warnings.length > 5 ? 'medium' : 'low';
+
+    return {
+      fieldsConverted: this.fieldMappings.length,
+      validationsConverted,
+      customLogicDetected: this.warnings.filter((warning) => warning.type === 'unsupported_type')
+        .length,
+      conversionAccuracy,
+      estimatedEffort,
+    };
+  }
+
+  private reset(): void {
+    this.errors = [];
+    this.warnings = [];
+    this.fieldMappings = [];
+    this.generatedTests = undefined;
+  }
+}

--- a/packages/form-engine/src/migration/index.ts
+++ b/packages/form-engine/src/migration/index.ts
@@ -1,0 +1,2 @@
+export * from './ZodMigrator';
+export * from './ReactFormMigrator';

--- a/packages/form-engine/src/testing/PathGenerator.ts
+++ b/packages/form-engine/src/testing/PathGenerator.ts
@@ -1,0 +1,315 @@
+import type { FormStep, Rule, StepTransition, UnifiedFormSchema } from '../types';
+
+export interface TestPath {
+  id: string;
+  steps: string[];
+  conditions: Record<string, Rule>;
+  data: Record<string, any>;
+  expectedOutcome: 'success' | 'validation_error' | 'blocked';
+}
+
+export interface PathGenerationOptions {
+  maxPaths?: number;
+  maxDepth?: number;
+  coverage?: 'minimal' | 'representative' | 'exhaustive';
+  includeInvalid?: boolean;
+  seed?: number;
+}
+
+type GenerationStrategy = 'default' | 'boundary';
+
+export class PathGenerator {
+  private paths: TestPath[] = [];
+  private visited: Set<string> = new Set();
+  private random: () => number = Math.random;
+
+  generatePaths(schema: UnifiedFormSchema, options: PathGenerationOptions = {}): TestPath[] {
+    this.reset();
+
+    if (!schema.steps.length) {
+      return [];
+    }
+
+    const config = {
+      maxPaths: options.maxPaths ?? 10,
+      maxDepth: options.maxDepth ?? 20,
+      coverage: options.coverage ?? 'representative',
+      includeInvalid: options.includeInvalid !== false,
+      seed: options.seed,
+    } as const;
+
+    this.random = this.createRng(config.seed);
+
+    switch (config.coverage) {
+      case 'minimal':
+        this.generatePath(schema, 'path-0', { strategy: 'default' });
+        break;
+      case 'exhaustive':
+        this.explorePaths(schema, schema.steps[0].id, [], {}, {}, 0, config.maxDepth);
+        this.generateBoundaryPaths(schema);
+        break;
+      case 'representative':
+      default:
+        this.explorePaths(schema, schema.steps[0].id, [], {}, {}, 0, config.maxDepth);
+        break;
+    }
+
+    if (config.includeInvalid) {
+      this.generateErrorPaths(schema);
+    }
+
+    return this.prunePaths(config.maxPaths);
+  }
+
+  private explorePaths(
+    schema: UnifiedFormSchema,
+    currentStep: string,
+    path: string[],
+    data: Record<string, any>,
+    conditions: Record<string, Rule>,
+    depth: number,
+    maxDepth: number,
+  ): void {
+    if (depth > maxDepth) {
+      return;
+    }
+
+    const pathKey = `${currentStep}|${path.join('>')}`;
+    if (this.visited.has(pathKey)) {
+      return;
+    }
+    this.visited.add(pathKey);
+
+    const newPath = [...path, currentStep];
+    const step = schema.steps.find((item) => item.id === currentStep);
+    const mergedData = { ...data, ...this.generateStepData(step, 'default') };
+
+    const transitions = schema.transitions.filter((transition) => transition.from === currentStep);
+    if (transitions.length === 0) {
+      this.paths.push({
+        id: `path-${this.paths.length}`,
+        steps: newPath,
+        conditions: { ...conditions },
+        data: mergedData,
+        expectedOutcome: 'success',
+      });
+      return;
+    }
+
+    transitions.forEach((transition) => {
+      const branchConditions = { ...conditions };
+      let branchData = { ...mergedData };
+
+      if (transition.when) {
+        const satisfyingData = this.generateDataForCondition(transition.when, schema);
+        branchData = { ...branchData, ...satisfyingData };
+        branchConditions[transition.to] = transition.when;
+      }
+
+      this.explorePaths(
+        schema,
+        transition.to,
+        newPath,
+        branchData,
+        branchConditions,
+        depth + 1,
+        maxDepth,
+      );
+    });
+  }
+
+  private generatePath(
+    schema: UnifiedFormSchema,
+    id: string,
+    options: { strategy: GenerationStrategy },
+  ): void {
+    if (!schema.steps.length) {
+      return;
+    }
+
+    const path: TestPath = {
+      id,
+      steps: [],
+      conditions: {},
+      data: {},
+      expectedOutcome: 'success',
+    };
+
+    let currentStep: FormStep | undefined = schema.steps[0];
+
+    while (currentStep) {
+      path.steps.push(currentStep.id);
+      const stepData = this.generateStepData(currentStep, options.strategy);
+      path.data = { ...path.data, ...stepData };
+
+      const transitions = schema.transitions.filter(
+        (transition) => transition.from === currentStep?.id,
+      );
+      if (transitions.length === 0) {
+        break;
+      }
+
+      const transition = this.selectTransition(transitions);
+      if (!transition) {
+        break;
+      }
+
+      if (transition.when) {
+        path.conditions[transition.to] = transition.when;
+        path.data = {
+          ...path.data,
+          ...this.generateDataForCondition(transition.when, schema),
+        };
+      }
+
+      currentStep = schema.steps.find((step) => step.id === transition.to);
+    }
+
+    this.paths.push(path);
+  }
+
+  private generateStepData(
+    step: FormStep | undefined,
+    strategy: GenerationStrategy,
+  ): Record<string, any> {
+    if (!step || typeof step.schema !== 'object') {
+      return {};
+    }
+
+    const data: Record<string, any> = {};
+    const properties = (step.schema as any).properties ?? {};
+
+    Object.entries(properties).forEach(([key, definition]) => {
+      data[key] = this.generateFieldValue(definition, strategy);
+    });
+
+    return data;
+  }
+
+  private generateFieldValue(schema: any, strategy: GenerationStrategy): any {
+    const type = schema?.type;
+    if (Array.isArray(type)) {
+      return this.generateFieldValue({ ...schema, type: type[0] }, strategy);
+    }
+
+    switch (type) {
+      case 'number':
+        if (strategy === 'boundary' && typeof schema.minimum === 'number') {
+          return schema.minimum;
+        }
+        return schema.minimum ?? 1;
+      case 'boolean':
+        return true;
+      case 'array':
+        return [];
+      case 'string':
+      default:
+        if (schema.enum && schema.enum.length > 0) {
+          return schema.enum[0];
+        }
+        if (schema.format === 'email') {
+          return 'test@example.com';
+        }
+        if (schema.format === 'date') {
+          return '2024-01-01';
+        }
+        return 'sample value';
+    }
+  }
+
+  private generateDataForCondition(
+    condition: Rule,
+    schema: UnifiedFormSchema,
+  ): Record<string, any> {
+    const data: Record<string, any> = {};
+
+    if (condition.op === 'eq' && typeof condition.left === 'string') {
+      const field = condition.left.replace('$.', '');
+      data[field] = condition.right;
+    }
+
+    if (condition.op === 'and' || condition.op === 'or') {
+      const args = (condition as any).args ?? [];
+      args.forEach((arg: Rule) => Object.assign(data, this.generateDataForCondition(arg, schema)));
+    }
+
+    return data;
+  }
+
+  private selectTransition(transitions: StepTransition[]): StepTransition | null {
+    if (transitions.length === 0) {
+      return null;
+    }
+
+    const defaultTransition = transitions.find((transition) => transition.default);
+    if (defaultTransition) {
+      return defaultTransition;
+    }
+
+    const index = Math.floor(this.random() * transitions.length);
+    return transitions[index] ?? null;
+  }
+
+  private generateBoundaryPaths(schema: UnifiedFormSchema): void {
+    schema.steps.forEach((step, index) => {
+      const id = `boundary-${index}`;
+      this.generatePath(schema, id, { strategy: 'boundary' });
+    });
+  }
+
+  private generateErrorPaths(schema: UnifiedFormSchema): void {
+    schema.steps.forEach((step) => {
+      if (!step.schema || typeof step.schema !== 'object') {
+        return;
+      }
+
+      const required = (step.schema as any).required ?? [];
+      if (!Array.isArray(required) || required.length === 0) {
+        return;
+      }
+
+      const invalidData: Record<string, any> = {};
+      required.forEach((field: string) => {
+        invalidData[field] = undefined;
+      });
+
+      this.paths.push({
+        id: `invalid-${step.id}-${this.paths.length}`,
+        steps: [step.id],
+        conditions: {},
+        data: invalidData,
+        expectedOutcome: 'validation_error',
+      });
+    });
+  }
+
+  private prunePaths(maxPaths: number): TestPath[] {
+    if (this.paths.length <= maxPaths) {
+      return this.paths;
+    }
+
+    return this.paths.slice(0, maxPaths);
+  }
+
+  private createRng(seed?: number): () => number {
+    if (typeof seed !== 'number') {
+      return Math.random;
+    }
+
+    let state = seed % 2147483647;
+    if (state <= 0) {
+      state += 2147483646;
+    }
+
+    return () => {
+      state = (state * 16807) % 2147483647;
+      return (state - 1) / 2147483646;
+    };
+  }
+
+  private reset(): void {
+    this.paths = [];
+    this.visited = new Set();
+    this.random = Math.random;
+  }
+}

--- a/packages/form-engine/src/types/index.ts
+++ b/packages/form-engine/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './ui.types';
 export * from './computed.types';
 export * from './events';
 export * from './analytics.types';
+export * from './migration.types';

--- a/packages/form-engine/src/types/migration.types.ts
+++ b/packages/form-engine/src/types/migration.types.ts
@@ -1,0 +1,56 @@
+import type { JSONSchema } from './json-schema.types';
+import type { UnifiedFormSchema } from './schema.types';
+
+export interface MigrationConfig {
+  source: 'zod' | 'react' | 'html' | 'json';
+  target: 'unified-schema';
+  options?: {
+    preserveComments?: boolean;
+    generateTests?: boolean;
+    validateOutput?: boolean;
+    interactive?: boolean;
+    customTransforms?: Record<string, (...args: any[]) => unknown>;
+  };
+}
+
+export interface MigrationResult {
+  success: boolean;
+  schema?: UnifiedFormSchema;
+  errors: MigrationError[];
+  warnings: MigrationWarning[];
+  stats: MigrationStats;
+  generatedTests?: string;
+}
+
+export interface MigrationError {
+  type: 'parse' | 'validation' | 'transform' | 'unknown';
+  message: string;
+  location?: {
+    line?: number;
+    column?: number;
+    file?: string;
+  };
+  suggestion?: string;
+}
+
+export interface MigrationWarning {
+  type: string;
+  message: string;
+  suggestion?: string;
+}
+
+export interface MigrationStats {
+  fieldsConverted: number;
+  validationsConverted: number;
+  customLogicDetected: number;
+  conversionAccuracy: number;
+  estimatedEffort: 'low' | 'medium' | 'high';
+}
+
+export interface FieldMapping {
+  source: string;
+  target: string;
+  transform?: (value: any) => any;
+  validation?: JSONSchema | Record<string, unknown> | null;
+  ui?: Record<string, unknown> | null;
+}

--- a/packages/form-engine/tests/unit/migration/ReactFormMigrator.test.ts
+++ b/packages/form-engine/tests/unit/migration/ReactFormMigrator.test.ts
@@ -1,0 +1,34 @@
+import { ReactFormMigrator } from '../../../src/migration/ReactFormMigrator';
+
+describe('ReactFormMigrator', () => {
+  it('extracts fields from JSX and builds a schema', async () => {
+    const component = `
+      import React from 'react';
+
+      export const SampleForm = () => (
+        <form>
+          <input name="fullName" required placeholder="Full name" />
+          <input name="age" type="number" />
+          <input name="email" type="email" />
+        </form>
+      );
+    `;
+
+    const migrator = new ReactFormMigrator();
+    const result = await migrator.migrateComponent(component);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.schema?.steps).toHaveLength(1);
+
+    const step = result.schema?.steps[0];
+    expect(step?.id).toBe('step-1');
+
+    const properties = (step?.schema as any).properties;
+    expect(Object.keys(properties)).toEqual(expect.arrayContaining(['fullName', 'age', 'email']));
+
+    const required = (step?.schema as any).required ?? [];
+    expect(required).toContain('fullName');
+    expect(required).not.toContain('age');
+  });
+});

--- a/packages/form-engine/tests/unit/migration/ZodMigrator.test.ts
+++ b/packages/form-engine/tests/unit/migration/ZodMigrator.test.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+import { ZodMigrator } from '../../../src/migration/ZodMigrator';
+
+describe('ZodMigrator', () => {
+  it('migrates simple Zod object into a unified schema', async () => {
+    const schema = z.object({
+      name: z.string().min(1),
+      age: z.number().min(18),
+      email: z.string().email().optional(),
+    });
+
+    const migrator = new ZodMigrator();
+    const result = await migrator.migrate(schema, {
+      validateOutput: true,
+      generateTests: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.schema?.steps).toHaveLength(1);
+    expect(result.generatedTests).toContain('Migrated Form');
+
+    const step = result.schema?.steps[0];
+    const stepSchema = step?.schema as any;
+    expect(stepSchema.required).toContain('name');
+    expect(stepSchema.required).toContain('age');
+    expect(stepSchema.required).not.toContain('email');
+
+    expect(result.stats.fieldsConverted).toBe(3);
+    expect(result.stats.validationsConverted).toBeGreaterThan(0);
+  });
+
+  it('collects warnings for unsupported types', async () => {
+    const schema = z.object({
+      payload: z.instanceof(Date),
+    });
+
+    const migrator = new ZodMigrator();
+    const result = await migrator.migrate(schema);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/form-engine/tests/unit/testing/PathGenerator.test.ts
+++ b/packages/form-engine/tests/unit/testing/PathGenerator.test.ts
@@ -1,0 +1,92 @@
+import { PathGenerator } from '../../../src/testing/PathGenerator';
+import type { UnifiedFormSchema } from '../../../src/types';
+
+describe('PathGenerator', () => {
+  const schema: UnifiedFormSchema = {
+    $id: 'test-schema',
+    version: '1.0.0',
+    metadata: {
+      title: 'Test Flow',
+      sensitivity: 'low',
+    },
+    steps: [
+      {
+        id: 'start',
+        title: 'Start',
+        schema: {
+          type: 'object',
+          properties: {
+            accepted: { type: 'boolean' },
+            age: { type: 'number', minimum: 18 },
+          },
+          required: ['accepted', 'age'],
+        },
+      },
+      {
+        id: 'details',
+        title: 'Additional Details',
+        schema: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', format: 'email' },
+          },
+          required: ['email'],
+        },
+      },
+      {
+        id: 'review',
+        title: 'Review',
+        schema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    ],
+    transitions: [
+      {
+        from: 'start',
+        to: 'details',
+        when: { op: 'eq', left: '$.accepted', right: true },
+      },
+      {
+        from: 'start',
+        to: 'review',
+        default: true,
+      },
+      {
+        from: 'details',
+        to: 'review',
+        default: true,
+      },
+    ],
+    ui: { widgets: {} },
+  };
+
+  it('generates representative paths through the form', () => {
+    const generator = new PathGenerator();
+    const paths = generator.generatePaths(schema, { coverage: 'representative', maxPaths: 5 });
+
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+    expect(paths.some((path) => path.steps.includes('details'))).toBe(true);
+    expect(paths.some((path) => path.data.accepted === true)).toBe(true);
+  });
+
+  it('creates a minimal happy path when requested', () => {
+    const generator = new PathGenerator();
+    const paths = generator.generatePaths(schema, { coverage: 'minimal', includeInvalid: false });
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0].expectedOutcome).toBe('success');
+  });
+
+  it('can skip invalid paths when includeInvalid is false', () => {
+    const generator = new PathGenerator();
+    const paths = generator.generatePaths(schema, {
+      coverage: 'representative',
+      includeInvalid: false,
+      maxPaths: 10,
+    });
+
+    expect(paths.every((path) => path.expectedOutcome === 'success')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add migration-focused types and export surface updates for the form engine package
- implement Zod and React migration helpers plus a path generator utility with reusable heuristics
- cover the new utilities with dedicated unit tests and extend dependencies to support parsing and conversions

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npm run size

## Step 10 Checklist
- [x] 10.2 Migration types created
- [x] 10.3 Zod schema migrator implemented
- [x] 10.4 React component migrator implemented
- [x] 10.5 Test path generator implemented

------
https://chatgpt.com/codex/tasks/task_e_68cc7b8c3dac832ab28b8bc47b26d2c0