### PR TITLE
feat(demo): add interactive demo form (step 11)

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,21 @@
+import { DemoForm } from '@/src/demo/DemoForm';
+import { Toaster } from '@/components/ui/sonner';
+
+export const metadata = {
+  title: 'Form Builder Demo',
+  description: 'Interactive demo form showcasing the schema driven engine.',
+};
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export default function DemoPage() {
+  return (
+    <main className="min-h-screen bg-slate-100 py-10">
+      <div className="container mx-auto max-w-5xl space-y-10 px-4">
+        <DemoForm />
+      </div>
+      <Toaster richColors position="top-right" />
+    </main>
+  );
+}

--- a/packages/form-engine/src/validation/worker-client.ts
+++ b/packages/form-engine/src/validation/worker-client.ts
@@ -117,7 +117,7 @@ export class ValidationWorkerClient {
 
   private initWorker(WorkerCtor: WorkerConstructorLike): void {
     try {
-      this.worker = new WorkerCtor(new URL('./validation.worker.js', import.meta.url), {
+      this.worker = new WorkerCtor(new URL('./validation.worker.ts', import.meta.url), {
         type: 'module',
       });
 

--- a/packages/form-engine/tests/demo/DemoForm.test.tsx
+++ b/packages/form-engine/tests/demo/DemoForm.test.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@form-engine/index', () => {
+  const React = require('react') as typeof import('react');
+  return {
+    FormRenderer: jest.fn(({ onSubmit }: { onSubmit: (data: Record<string, unknown>) => void }) => {
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit({});
+          }}
+        >
+          <button type="submit">Submit</button>
+        </form>
+      ) as ReactElement;
+    }),
+    useFormAnalytics: jest.fn(() => ({
+      trackStepView: jest.fn(),
+      trackFieldInteraction: jest.fn(),
+      trackValidation: jest.fn(),
+      trackSubmission: jest.fn(),
+      measureStepTransition: jest.fn(() => jest.fn()),
+      startValidationMeasurement: jest.fn(() => jest.fn()),
+      getSessionId: jest.fn(() => 'session-123'),
+      getSessionMetrics: jest.fn(() => ({ startTime: Date.now() - 1000, endTime: Date.now() })),
+    })),
+    PersistenceManager: jest.fn().mockImplementation(() => ({
+      loadDraft: jest.fn().mockResolvedValue(null),
+      saveDraft: jest.fn().mockResolvedValue(undefined),
+      flushPendingSaves: jest.fn().mockResolvedValue(undefined),
+      deleteDraft: jest.fn().mockResolvedValue(undefined),
+    })),
+    PerformanceDashboard: jest.fn(() => <div data-testid="performance-dashboard" />),
+  };
+});
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+import { DemoForm } from '../../../../src/demo/DemoForm';
+
+describe('DemoForm', () => {
+  it('renders the demo form header once ready', async () => {
+    render(<DemoForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Employment Application Demo')).toBeInTheDocument();
+    });
+  });
+
+  it('toggles performance dashboard visibility label', async () => {
+    render(<DemoForm />);
+
+    const toggle = await screen.findByRole('button', { name: /show performance/i });
+    fireEvent.click(toggle);
+
+    expect(await screen.findByRole('button', { name: /hide performance/i })).toBeInTheDocument();
+  });
+});

--- a/src/demo/DemoForm.tsx
+++ b/src/demo/DemoForm.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { toast } from 'sonner';
+
+import {
+  FormRenderer,
+  PerformanceDashboard,
+  PersistenceManager,
+  type DraftData,
+  useFormAnalytics,
+} from '@form-engine/index';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { DemoDraftRecovery } from './components/DemoDraftRecovery';
+import { demoFormSchema } from './DemoFormSchema';
+
+const AUTOSAVE_INTERVAL = 5000;
+const INITIAL_STEP = demoFormSchema.steps[0]?.id ?? 'personal';
+
+type AutosaveState = {
+  isSaving: boolean;
+  lastSavedAt: number | null;
+  saveCount: number;
+};
+
+const createInitialAutosaveState = (): AutosaveState => ({
+  isSaving: false,
+  lastSavedAt: null,
+  saveCount: 0,
+});
+
+const isSafeSegment = (segment: string): boolean => {
+  return segment !== '__proto__' && segment !== 'constructor' && segment !== 'prototype';
+};
+
+const applyValueAtPath = (
+  data: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): Record<string, unknown> => {
+  if (!path) {
+    return value === undefined ? data : { ...data };
+  }
+
+  const segments = path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter(Boolean);
+  if (segments.some((segment) => !isSafeSegment(segment))) {
+    return data;
+  }
+
+  const next = { ...data };
+  let cursor: Record<string, unknown> | unknown[] = next;
+
+  segments.slice(0, -1).forEach((segment, index) => {
+    const nextSegment = segments[index + 1];
+    if (Array.isArray(cursor)) {
+      const arrayCursor = cursor as unknown[];
+      const indexKey = Number(segment);
+      if (Number.isNaN(indexKey)) {
+        return;
+      }
+      const existing = arrayCursor[indexKey];
+      let updated: unknown;
+      if (Array.isArray(existing)) {
+        updated = [...existing];
+      } else if (existing && typeof existing === 'object') {
+        updated = { ...(existing as Record<string, unknown>) };
+      } else {
+        updated = nextSegment && /^\d+$/.test(nextSegment) ? [] : {};
+      }
+      arrayCursor[indexKey] = updated;
+      cursor = updated as Record<string, unknown> | unknown[];
+      return;
+    }
+
+    const recordCursor = cursor as Record<string, unknown>;
+    const existing = recordCursor[segment];
+    let updated: unknown;
+    if (Array.isArray(existing)) {
+      updated = [...existing];
+    } else if (existing && typeof existing === 'object') {
+      updated = { ...(existing as Record<string, unknown>) };
+    } else {
+      updated = nextSegment && /^\d+$/.test(nextSegment) ? [] : {};
+    }
+    recordCursor[segment] = updated;
+    cursor = updated as Record<string, unknown> | unknown[];
+  });
+
+  const lastKey = segments[segments.length - 1];
+  if (!lastKey) {
+    return next;
+  }
+
+  if (Array.isArray(cursor)) {
+    const index = Number(lastKey);
+    if (Number.isNaN(index)) {
+      return next;
+    }
+    if (value === undefined || value === null) {
+      (cursor as unknown[]).splice(index, 1);
+    } else {
+      (cursor as unknown[])[index] = value as never;
+    }
+    return next;
+  }
+
+  if (value === undefined || value === null) {
+    delete (cursor as Record<string, unknown>)[lastKey];
+  } else {
+    (cursor as Record<string, unknown>)[lastKey] = value;
+  }
+
+  return next;
+};
+
+const formatLastSaved = (state: AutosaveState): string => {
+  if (state.isSaving) {
+    return 'Saving draft…';
+  }
+  if (state.lastSavedAt) {
+    return `Last saved ${formatDistanceToNow(state.lastSavedAt, { addSuffix: true })}`;
+  }
+  return 'Autosave pending';
+};
+
+export const DemoForm = () => {
+  const [formInstanceKey, setFormInstanceKey] = useState(0);
+  const [initialData, setInitialData] = useState<Record<string, unknown> | undefined>(undefined);
+  const [formData, setFormData] = useState<Record<string, unknown>>({});
+  const [currentStep, setCurrentStep] = useState<string>(INITIAL_STEP);
+  const [completedSteps, setCompletedSteps] = useState<string[]>([]);
+  const [draft, setDraft] = useState<DraftData | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [showPerformance, setShowPerformance] = useState(false);
+  const [autosaveState, setAutosaveState] = useState<AutosaveState>(createInitialAutosaveState);
+  const [submittedData, setSubmittedData] = useState<Record<string, unknown> | null>(null);
+  const [showResults, setShowResults] = useState(false);
+
+  const persistenceRef = useRef<PersistenceManager | null>(null);
+  const autosaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const previousStepRef = useRef<string>(INITIAL_STEP);
+
+  const analytics = useFormAnalytics(demoFormSchema.$id, demoFormSchema.version, {
+    enabled: true,
+    sampling: 1,
+    sensitive: true,
+    performanceBudgets: {
+      stepTransition: 150,
+      validation: 60,
+      initialLoad: 400,
+    },
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const manager = new PersistenceManager({
+      formId: demoFormSchema.$id,
+      schemaVersion: demoFormSchema.version,
+      allowAutosave: true,
+      sensitivity: demoFormSchema.metadata.sensitivity,
+    });
+
+    persistenceRef.current = manager;
+    let mounted = true;
+
+    manager
+      .loadDraft()
+      .then((loadedDraft) => {
+        if (!mounted) {
+          return;
+        }
+        if (loadedDraft) {
+          setDraft(loadedDraft);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load draft', error);
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsReady(true);
+        }
+      });
+
+    return () => {
+      mounted = false;
+      persistenceRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (autosaveTimeoutRef.current) {
+        clearTimeout(autosaveTimeoutRef.current);
+        autosaveTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isReady || !persistenceRef.current) {
+      return;
+    }
+
+    if (autosaveTimeoutRef.current) {
+      clearTimeout(autosaveTimeoutRef.current);
+    }
+
+    autosaveTimeoutRef.current = setTimeout(() => {
+      const manager = persistenceRef.current;
+      if (!manager) {
+        return;
+      }
+
+      setAutosaveState((prev) => ({ ...prev, isSaving: true }));
+
+      manager
+        .saveDraft(formData, currentStep, completedSteps)
+        .then(() => manager.flushPendingSaves())
+        .then(() => {
+          setAutosaveState((prev) => ({
+            isSaving: false,
+            lastSavedAt: Date.now(),
+            saveCount: prev.saveCount + 1,
+          }));
+        })
+        .catch((error) => {
+          console.error('Failed to persist draft', error);
+          setAutosaveState((prev) => ({ ...prev, isSaving: false }));
+        });
+    }, AUTOSAVE_INTERVAL);
+
+    return () => {
+      if (autosaveTimeoutRef.current) {
+        clearTimeout(autosaveTimeoutRef.current);
+        autosaveTimeoutRef.current = null;
+      }
+    };
+  }, [completedSteps, currentStep, formData, isReady]);
+
+  const handleFieldChange = useCallback(
+    (field: string, value: unknown) => {
+      setFormData((prev) => applyValueAtPath(prev, field, value));
+      analytics.trackFieldInteraction(field, value, 'change');
+    },
+    [analytics],
+  );
+
+  const handleStepChange = useCallback(
+    (nextStep: string) => {
+      const previous = previousStepRef.current;
+      if (previous && previous !== nextStep) {
+        const measure = analytics.measureStepTransition(previous, nextStep);
+        measure?.();
+        setCompletedSteps((prev) => (prev.includes(previous) ? prev : [...prev, previous]));
+      }
+      analytics.trackStepView(nextStep);
+      previousStepRef.current = nextStep;
+      setCurrentStep(nextStep);
+    },
+    [analytics],
+  );
+
+  const handleValidationError = useCallback(
+    (errors: unknown) => {
+      const step = previousStepRef.current ?? currentStep;
+      analytics.trackValidation(step, (errors as Record<string, unknown>) ?? {}, false);
+    },
+    [analytics, currentStep],
+  );
+
+  const resetFormState = useCallback(() => {
+    setFormInstanceKey((key) => key + 1);
+    setInitialData(undefined);
+    setFormData({});
+    setCompletedSteps([]);
+    setCurrentStep(INITIAL_STEP);
+    previousStepRef.current = INITIAL_STEP;
+    setAutosaveState(createInitialAutosaveState());
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (data: Record<string, unknown>) => {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+        analytics.trackValidation('submission', {}, true);
+        analytics.trackSubmission(true, data);
+        setSubmittedData(data);
+        setShowResults(true);
+        toast.success('Application submitted successfully', {
+          description: 'Thank you for completing the demo application. We will be in touch soon.',
+        });
+        await persistenceRef.current?.deleteDraft();
+        resetFormState();
+      } catch (error) {
+        analytics.trackSubmission(false, data, error as Error);
+        toast.error('Unable to submit application', {
+          description: (error as Error)?.message ?? 'Please try again shortly.',
+        });
+      }
+    },
+    [analytics, resetFormState],
+  );
+
+  const handleDraftRecover = useCallback((nextDraft: DraftData) => {
+    const recoveredData = (nextDraft.data as Record<string, unknown>) ?? {};
+    setInitialData(recoveredData);
+    setFormData(recoveredData);
+    setCompletedSteps(nextDraft.completedSteps);
+    setCurrentStep(nextDraft.currentStep);
+    previousStepRef.current = nextDraft.currentStep;
+    setAutosaveState((prev) => ({
+      ...prev,
+      lastSavedAt: Date.parse(nextDraft.metadata.updatedAt) || Date.now(),
+      saveCount: nextDraft.metadata.saveCount,
+      isSaving: false,
+    }));
+    setDraft(null);
+    toast.success('Draft recovered', {
+      description: 'You can continue where you left off.',
+    });
+  }, []);
+
+  const handleDraftDiscard = useCallback(async () => {
+    try {
+      await persistenceRef.current?.deleteDraft();
+    } catch (error) {
+      console.error('Failed to delete draft', error);
+    }
+    setDraft(null);
+    resetFormState();
+    toast.info('Draft discarded', {
+      description: 'The saved draft has been removed.',
+    });
+  }, [resetFormState]);
+
+  const sessionMetrics = analytics.getSessionMetrics();
+
+  if (!isReady) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-32 w-96" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-4 rounded-lg border bg-white p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">{demoFormSchema.metadata.title}</h1>
+          <p className="text-sm text-slate-600">{demoFormSchema.metadata.description}</p>
+        </div>
+        <div className="flex flex-col items-start gap-3 sm:items-end">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">Step: {currentStep}</Badge>
+            <Badge variant="outline">Completed: {completedSteps.length}</Badge>
+            <Badge variant="outline">{formatLastSaved(autosaveState)}</Badge>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => setShowPerformance((value) => !value)}>
+            {showPerformance ? 'Hide performance' : 'Show performance'}
+          </Button>
+        </div>
+      </header>
+
+      {draft ? (
+        <DemoDraftRecovery
+          draft={draft}
+          onRecover={handleDraftRecover}
+          onDiscard={handleDraftDiscard}
+        />
+      ) : null}
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm">
+        <FormRenderer
+          key={formInstanceKey}
+          schema={demoFormSchema}
+          initialData={initialData}
+          onSubmit={handleSubmit}
+          onStepChange={handleStepChange}
+          onFieldChange={handleFieldChange}
+          onValidationError={handleValidationError}
+          className="space-y-6"
+        />
+      </div>
+
+      {showPerformance ? <PerformanceDashboard show /> : null}
+
+      <Dialog open={showResults} onOpenChange={setShowResults}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Application submitted</DialogTitle>
+            <DialogDescription>
+              We captured the form payload below so you can inspect what is sent through the engine.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 text-sm">
+            <div className="rounded border border-emerald-200 bg-emerald-50 p-4 text-emerald-900">
+              Submission succeeded in this session. The analytics session ID is{' '}
+              <span className="font-mono text-xs">{analytics.getSessionId() ?? 'n/a'}</span>.
+            </div>
+            {sessionMetrics ? (
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <div>
+                  <span className="text-slate-500">Started:</span>{' '}
+                  {new Date(sessionMetrics.startTime).toLocaleTimeString()}
+                </div>
+                <div>
+                  <span className="text-slate-500">Duration:</span>{' '}
+                  {Math.round((sessionMetrics.endTime - sessionMetrics.startTime) / 1000)} seconds
+                </div>
+              </div>
+            ) : null}
+            <pre className="max-h-80 overflow-auto rounded bg-slate-900 p-4 text-xs text-slate-100">
+              {JSON.stringify(submittedData, null, 2)}
+            </pre>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};

--- a/src/demo/DemoFormSchema.ts
+++ b/src/demo/DemoFormSchema.ts
@@ -1,0 +1,536 @@
+import type { UnifiedFormSchema } from '@form-engine/index';
+
+export const demoFormSchema: UnifiedFormSchema = {
+  $id: 'employment-application-demo',
+  version: '1.0.0',
+  metadata: {
+    title: 'Employment Application Demo',
+    description:
+      'Comprehensive job application demonstrating validation, branching, and persistence.',
+    sensitivity: 'high',
+    allowAutosave: true,
+    retainHidden: false,
+    requiresAudit: true,
+    tags: ['demo', 'employment', 'multi-step'],
+    owner: 'Form Experience Team',
+    lastModified: new Date().toISOString(),
+  },
+  definitions: {
+    phoneNumber: {
+      type: 'string',
+      pattern: '^(\\+?[0-9\\s-]{7,15})$',
+      description: 'International format is supported.',
+    },
+    url: {
+      type: 'string',
+      format: 'uri',
+    },
+  },
+  steps: [
+    {
+      id: 'personal',
+      title: 'Personal Information',
+      description: 'Share how we can get in touch and verify your eligibility.',
+      schema: {
+        type: 'object',
+        properties: {
+          firstName: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 50,
+          },
+          lastName: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 50,
+          },
+          email: {
+            type: 'string',
+            format: 'email',
+          },
+          phone: {
+            $ref: '#/definitions/phoneNumber',
+          },
+          dateOfBirth: {
+            type: 'string',
+            format: 'date',
+          },
+        },
+        required: ['firstName', 'lastName', 'email', 'dateOfBirth'],
+      },
+    },
+    {
+      id: 'employment',
+      title: 'Employment Status',
+      description: 'Tell us about your current working situation.',
+      visibleWhen: {
+        op: 'gte',
+        left: '$.age',
+        right: 18,
+      },
+      schema: {
+        type: 'object',
+        properties: {
+          currentStatus: {
+            type: 'string',
+            enum: ['employed', 'self-employed', 'unemployed', 'student'],
+          },
+          employer: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 100,
+            'x-visibility': {
+              op: 'in',
+              left: '$.currentStatus',
+              right: ['employed', 'self-employed'],
+            },
+          },
+          position: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 100,
+            'x-visibility': {
+              op: 'in',
+              left: '$.currentStatus',
+              right: ['employed', 'self-employed'],
+            },
+          },
+          salary: {
+            type: 'number',
+            minimum: 0,
+            maximum: 1000000,
+            'x-visibility': {
+              op: 'eq',
+              left: '$.currentStatus',
+              right: 'employed',
+            },
+          },
+          startDate: {
+            type: 'string',
+            format: 'date',
+            'x-visibility': {
+              op: 'in',
+              left: '$.currentStatus',
+              right: ['employed', 'self-employed'],
+            },
+          },
+        },
+        required: ['currentStatus'],
+      },
+    },
+    {
+      id: 'experience',
+      title: 'Experience & Highlights',
+      description: 'Summarise your recent experience and standout work.',
+      visibleWhen: {
+        op: 'in',
+        left: '$.currentStatus',
+        right: ['employed', 'self-employed', 'unemployed'],
+      },
+      schema: {
+        type: 'object',
+        properties: {
+          yearsExperience: {
+            type: 'number',
+            minimum: 0,
+            maximum: 50,
+          },
+          keySkills: {
+            type: 'string',
+            minLength: 3,
+            maxLength: 500,
+          },
+          highlightProjects: {
+            type: 'string',
+            maxLength: 1000,
+          },
+        },
+        required: ['yearsExperience'],
+      },
+    },
+    {
+      id: 'education',
+      title: 'Education',
+      description: 'Provide the most relevant details about your education.',
+      schema: {
+        type: 'object',
+        properties: {
+          highestDegree: {
+            type: 'string',
+            enum: ['high-school', 'associates', 'bachelors', 'masters', 'doctorate'],
+          },
+          institution: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 120,
+          },
+          graduationYear: {
+            type: 'number',
+            minimum: 1950,
+            maximum: new Date().getFullYear(),
+          },
+          gpa: {
+            type: 'number',
+            minimum: 0,
+            maximum: 4,
+            'x-visibility': {
+              op: 'in',
+              left: '$.highestDegree',
+              right: ['associates', 'bachelors', 'masters', 'doctorate'],
+            },
+          },
+        },
+        required: ['highestDegree'],
+      },
+    },
+    {
+      id: 'preferences',
+      title: 'Role Preferences',
+      description: 'Help us tailor opportunities to what matters most to you.',
+      schema: {
+        type: 'object',
+        properties: {
+          jobType: {
+            type: 'string',
+            enum: ['full-time', 'part-time', 'contract', 'internship'],
+          },
+          remotePreference: {
+            type: 'string',
+            enum: ['remote', 'hybrid', 'onsite'],
+          },
+          salaryExpectation: {
+            type: 'number',
+            minimum: 0,
+            maximum: 1000000,
+          },
+          availabilityDate: {
+            type: 'string',
+            format: 'date',
+          },
+          relocate: {
+            type: 'boolean',
+          },
+          preferredLocation: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 120,
+            'x-visibility': {
+              op: 'not',
+              args: [
+                {
+                  op: 'eq',
+                  left: '$.relocate',
+                  right: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      id: 'legal',
+      title: 'Declarations',
+      description: 'Confirm your eligibility to work with us.',
+      schema: {
+        type: 'object',
+        properties: {
+          workAuthorization: {
+            type: 'boolean',
+          },
+          requiresSponsorship: {
+            type: 'boolean',
+            'x-visibility': {
+              op: 'eq',
+              left: '$.workAuthorization',
+              right: false,
+            },
+          },
+          backgroundCheckConsent: {
+            type: 'boolean',
+          },
+        },
+        required: ['workAuthorization', 'backgroundCheckConsent'],
+      },
+    },
+    {
+      id: 'review',
+      title: 'Review & Submit',
+      description: 'One final step before we submit your application.',
+      schema: {
+        type: 'object',
+        properties: {
+          confirmAccuracy: {
+            type: 'boolean',
+          },
+          coverLetter: {
+            type: 'string',
+            maxLength: 2000,
+          },
+        },
+        required: ['confirmAccuracy'],
+      },
+    },
+  ],
+  transitions: [
+    {
+      from: 'personal',
+      to: 'education',
+      when: {
+        op: 'lt',
+        left: '$.age',
+        right: 18,
+      },
+    },
+    {
+      from: 'personal',
+      to: 'employment',
+      default: true,
+    },
+    {
+      from: 'employment',
+      to: 'experience',
+      when: {
+        op: 'in',
+        left: '$.currentStatus',
+        right: ['employed', 'self-employed', 'unemployed'],
+      },
+    },
+    {
+      from: 'employment',
+      to: 'education',
+      default: true,
+    },
+    {
+      from: 'experience',
+      to: 'education',
+      default: true,
+    },
+    {
+      from: 'education',
+      to: 'preferences',
+      default: true,
+    },
+    {
+      from: 'preferences',
+      to: 'legal',
+      default: true,
+    },
+    {
+      from: 'legal',
+      to: 'review',
+      default: true,
+    },
+  ],
+  ui: {
+    layout: {
+      type: 'single-column',
+      gutter: 24,
+    },
+    theme: {
+      brandColor: '#1d4ed8',
+      accentColor: '#0f172a',
+      density: 'comfortable',
+      cornerRadius: 'md',
+      tone: 'light',
+    },
+    widgets: {
+      firstName: {
+        component: 'Text',
+        label: 'First name',
+        placeholder: 'Jane',
+      },
+      lastName: {
+        component: 'Text',
+        label: 'Last name',
+        placeholder: 'Doe',
+      },
+      email: {
+        component: 'Text',
+        label: 'Email address',
+        placeholder: 'jane.doe@example.com',
+        description: 'We will use this email for all communication.',
+      },
+      phone: {
+        component: 'Text',
+        label: 'Phone number',
+        placeholder: '+1 202 555 0108',
+      },
+      dateOfBirth: {
+        component: 'Date',
+        label: 'Date of birth',
+      },
+      currentStatus: {
+        component: 'Select',
+        label: 'Current employment status',
+        placeholder: 'Select status',
+        options: [
+          { value: 'employed', label: 'Employed' },
+          { value: 'self-employed', label: 'Self-employed' },
+          { value: 'unemployed', label: 'Between roles' },
+          { value: 'student', label: 'Student' },
+        ],
+      },
+      employer: {
+        component: 'Text',
+        label: 'Employer name',
+        placeholder: 'Acme Corp',
+      },
+      position: {
+        component: 'Text',
+        label: 'Role / Title',
+        placeholder: 'Senior Developer',
+      },
+      salary: {
+        component: 'Number',
+        label: 'Monthly salary',
+        helpText: 'Enter your gross monthly salary in GBP.',
+      },
+      startDate: {
+        component: 'Date',
+        label: 'Start date',
+      },
+      yearsExperience: {
+        component: 'Number',
+        label: 'Years of professional experience',
+      },
+      keySkills: {
+        component: 'TextArea',
+        label: 'Key skills',
+        placeholder: 'React, accessibility, stakeholder management...',
+        description: 'Comma separated list of skills you are confident in.',
+      },
+      highlightProjects: {
+        component: 'TextArea',
+        label: 'Highlight a project',
+        placeholder: 'Share a project you are proud of.',
+      },
+      highestDegree: {
+        component: 'Select',
+        label: 'Highest qualification',
+        placeholder: 'Select degree',
+        options: [
+          { value: 'high-school', label: 'High school / GCSE' },
+          { value: 'associates', label: 'Associate degree' },
+          { value: 'bachelors', label: "Bachelor's degree" },
+          { value: 'masters', label: "Master's degree" },
+          { value: 'doctorate', label: 'Doctorate (PhD)' },
+        ],
+      },
+      institution: {
+        component: 'Text',
+        label: 'Institution name',
+      },
+      graduationYear: {
+        component: 'Number',
+        label: 'Graduation year',
+      },
+      gpa: {
+        component: 'Number',
+        label: 'GPA / Final score',
+      },
+      jobType: {
+        component: 'Select',
+        label: 'Preferred job type',
+        placeholder: 'Select type',
+        options: [
+          { value: 'full-time', label: 'Full-time' },
+          { value: 'part-time', label: 'Part-time' },
+          { value: 'contract', label: 'Contract' },
+          { value: 'internship', label: 'Internship' },
+        ],
+      },
+      remotePreference: {
+        component: 'Select',
+        label: 'Work location preference',
+        placeholder: 'Choose an option',
+        options: [
+          { value: 'remote', label: 'Remote' },
+          { value: 'hybrid', label: 'Hybrid' },
+          { value: 'onsite', label: 'On-site' },
+        ],
+      },
+      salaryExpectation: {
+        component: 'Number',
+        label: 'Expected annual salary (GBP)',
+      },
+      availabilityDate: {
+        component: 'Date',
+        label: 'Earliest start date',
+      },
+      relocate: {
+        component: 'Checkbox',
+        label: 'I am open to relocating',
+      },
+      preferredLocation: {
+        component: 'Text',
+        label: 'Preferred location',
+      },
+      workAuthorization: {
+        component: 'Checkbox',
+        label: 'I am authorised to work in the UK',
+      },
+      requiresSponsorship: {
+        component: 'Checkbox',
+        label: 'I require sponsorship to work in the UK',
+      },
+      backgroundCheckConsent: {
+        component: 'Checkbox',
+        label: 'I consent to background screening',
+      },
+      confirmAccuracy: {
+        component: 'Checkbox',
+        label: 'I confirm the information provided is accurate',
+      },
+      coverLetter: {
+        component: 'TextArea',
+        label: 'Cover letter',
+        placeholder: 'Introduce yourself and tell us why you are a great fit.',
+      },
+    },
+  },
+  computed: [
+    {
+      path: '$.age',
+      expr: 'year(today()) - year(dateOfBirth)',
+      dependsOn: ['$.dateOfBirth'],
+      recompute: 'onChange',
+    },
+    {
+      path: '$.fullName',
+      expr: 'trim(concat(firstName, " ", lastName))',
+      dependsOn: ['$.firstName', '$.lastName'],
+      recompute: 'onChange',
+    },
+    {
+      path: '$.annualSalary',
+      expr: 'salary * 12',
+      dependsOn: ['$.salary'],
+      round: 0,
+      recompute: 'onChange',
+    },
+  ],
+  dataSources: {
+    employmentStatuses: {
+      type: 'static',
+      data: [
+        { value: 'employed', label: 'Employed' },
+        { value: 'self-employed', label: 'Self-employed' },
+        { value: 'unemployed', label: 'Between roles' },
+        { value: 'student', label: 'Student' },
+      ],
+    },
+    jobLocations: {
+      type: 'static',
+      data: [
+        { value: 'london', label: 'London' },
+        { value: 'manchester', label: 'Manchester' },
+        { value: 'remote', label: 'Fully remote' },
+      ],
+    },
+  },
+  validation: {
+    strategy: 'onBlur',
+    debounceMs: 120,
+  },
+};

--- a/src/demo/components/DemoDraftRecovery.tsx
+++ b/src/demo/components/DemoDraftRecovery.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Info } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+
+import type { DraftData } from '@form-engine/index';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+interface DemoDraftRecoveryProps {
+  draft: DraftData;
+  onRecover: (draft: DraftData) => void;
+  onDiscard: (draft: DraftData) => void;
+}
+
+export const DemoDraftRecovery = ({ draft, onRecover, onDiscard }: DemoDraftRecoveryProps) => {
+  const draftAge = useMemo(() => {
+    return formatDistanceToNow(new Date(draft.metadata.updatedAt), {
+      addSuffix: true,
+    });
+  }, [draft.metadata.updatedAt]);
+
+  return (
+    <Alert className="border-blue-200 bg-blue-50 text-blue-900">
+      <AlertTitle className="flex items-center gap-2 text-blue-900">
+        <Info aria-hidden className="h-4 w-4" />
+        Unsaved draft detected
+      </AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>
+          We found a draft saved {draftAge}. You can continue from where you left off or start a
+          fresh application.
+        </p>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <span className="rounded bg-blue-100 px-2 py-1 font-medium">
+            Step: {draft.currentStep}
+          </span>
+          <span className="rounded bg-blue-100 px-2 py-1 font-medium">
+            Progress: {draft.completedSteps.length} completed
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" onClick={() => onRecover(draft)}>
+            Recover draft
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onDiscard(draft)}>
+            Start over
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+};

--- a/src/demo/types.ts
+++ b/src/demo/types.ts
@@ -1,0 +1,48 @@
+export interface DemoFormData {
+  // Personal Information
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  dateOfBirth: string;
+
+  // Computed fields
+  age?: number;
+  fullName?: string;
+  annualSalary?: number;
+
+  // Employment
+  currentStatus?: 'employed' | 'self-employed' | 'unemployed' | 'student';
+  employer?: string;
+  position?: string;
+  salary?: number;
+  startDate?: string;
+
+  // Experience
+  yearsExperience?: number;
+  keySkills?: string;
+  highlightProjects?: string;
+
+  // Education
+  highestDegree?: 'high-school' | 'associates' | 'bachelors' | 'masters' | 'doctorate';
+  institution?: string;
+  graduationYear?: number;
+  gpa?: number;
+
+  // Preferences
+  jobType?: 'full-time' | 'part-time' | 'contract' | 'internship';
+  remotePreference?: 'remote' | 'hybrid' | 'onsite';
+  salaryExpectation?: number;
+  availabilityDate?: string;
+  relocate?: boolean;
+  preferredLocation?: string;
+
+  // Legal & Agreements
+  workAuthorization?: boolean;
+  requiresSponsorship?: boolean;
+  backgroundCheckConsent: boolean;
+  confirmAccuracy: boolean;
+
+  // Additional
+  coverLetter?: string;
+}


### PR DESCRIPTION
## Summary
- add a schema-driven employment application demo with branching steps, computed fields, and UI metadata
- implement the DemoForm client experience with autosave persistence, analytics hooks, draft recovery, and submission dialog
- expose the /demo route, add unit coverage for the demo, and ensure the validation worker resolves the TS module at build time

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npm run size

------
https://chatgpt.com/codex/tasks/task_e_68cc8250c2e4832a98169b59b4e44ab8