### PR TITLE
feat(form-engine): enforce session timeout (step P2-04)

### DIFF
--- a/docs/form-builder/PHASE-2-Tracker.v2.md
+++ b/docs/form-builder/PHASE-2-Tracker.v2.md
@@ -3,10 +3,10 @@
 Initialized: 2025-09-22 08:00 BST
 
 ## Checklist
-- [ ] P2‑01 — Repeater (arrays)
-- [ ] P2‑02 — UK Postcode widget (+ AJV format)
-- [ ] P2‑03 — Submission retry & draft recovery
-- [ ] P2‑04 — Session timeout enforcement
+- [x] P2‑01 — Repeater (arrays)
+- [x] P2‑02 — UK Postcode widget (+ AJV format)
+- [x] P2‑03 — Submission retry & draft recovery
+- [x] P2‑04 — Session timeout enforcement
 - [ ] P2‑05 — CSP with nonce
 - [ ] P2‑06 — Schema composer override guard
 - [ ] P2‑07 — Analytics: `v` + `payloadVersion`
@@ -27,6 +27,10 @@ Initialized: 2025-09-22 08:00 BST
 ## Log
 | ID   | Summary | Commit | CI Run | Notes |
 |------|---------|--------|--------|-------|
+| P2‑01 | Repeater (arrays) | b5ddf005bb16dfb5866cb08b591a8841239fa0d7 | local (lint/typecheck/test/build/size) | Rebuilt repeater with leaner field-array wiring, keeping min/max and a11y cues. |
+| P2‑02 | UK Postcode widget (+ AJV format) | ce909add284a37824a1fcf66205d86ac5010a879 | local (format/lint/typecheck/test/build/size) | Added masked Postcode widget and gb-postcode AJV format with regression tests. |
+| P2‑03 | Submission retry & draft recovery | 2a17b3f6e8c5d47c997a23340f90158c875c600a | local (format/lint/typecheck/test/build/size) | Added exponential retry with aria-live feedback and lazy draft autosave to keep bundle budget intact. |
+| P2‑04 | Session timeout enforcement | ac44e4b1d2ac97b359da6fd8ef0953f47662cc03 | local (format/lint/typecheck/test/build/size) | Countdown + lock/restore UX landed; lint still reports existing `any` warnings, build skipped font download offline. |
 
 ## CI Summary (latest)
-- Lint: ☐/☑ | Typecheck: ☐/☑ | Tests: ☐/☑ | Build: ☐/☑ | Size: ☐/☑
+- Lint: ☑ | Typecheck: ☑ | Tests: ☑ | Build: ☑ | Size: ☑

--- a/packages/form-engine/src/components/fields/RepeaterField.tsx
+++ b/packages/form-engine/src/components/fields/RepeaterField.tsx
@@ -1,0 +1,354 @@
+'use client';
+
+import * as React from 'react';
+import {
+  type ArrayPath,
+  type Control,
+  type FieldArray,
+  type FieldArrayWithId,
+  type FieldValues,
+  type Path,
+  useFieldArray,
+  useFormContext,
+} from 'react-hook-form';
+
+import type { RepeaterItemConfig } from '../../types';
+import { cn } from '../../utils/cn';
+import { FieldFactory } from './FieldFactory';
+import type { FieldProps } from './types';
+
+interface RepeaterComponentProps {
+  fields?: RepeaterItemConfig[];
+  itemLabel?: string;
+  addButtonLabel?: string;
+  removeButtonLabel?: string;
+  moveUpLabel?: string;
+  moveDownLabel?: string;
+  emptyStateText?: string;
+  minItems?: number;
+  maxItems?: number;
+  defaultItemValue?: Record<string, unknown>;
+}
+
+const ANNOUNCEMENT_RESET_DELAY = 1500;
+const DEFAULT_EMPTY_TEXT = 'No items yet.';
+const DEFAULT_ITEM_LABEL = 'Item';
+const DEFAULT_REMOVE_LABEL = 'Remove';
+const DEFAULT_MOVE_UP_LABEL = 'Move up';
+const DEFAULT_MOVE_DOWN_LABEL = 'Move down';
+
+const buildDefaultItem = (
+  configs: RepeaterItemConfig[],
+  fallback?: Record<string, unknown>,
+): Record<string, unknown> => {
+  const seededFromConfig = configs.reduce<Record<string, unknown>>((acc, config) => {
+    if (config.defaultValue !== undefined) {
+      acc[config.name] = config.defaultValue;
+    }
+    return acc;
+  }, {});
+
+  return {
+    ...(fallback ?? {}),
+    ...seededFromConfig,
+  };
+};
+
+const getErrorMessage = (error: unknown): string | undefined => {
+  if (!error) {
+    return undefined;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' ? message : undefined;
+  }
+
+  return undefined;
+};
+
+export const RepeaterField = <TFieldValues extends FieldValues = FieldValues>({
+  name,
+  control,
+  componentProps,
+  className,
+  disabled,
+  readOnly,
+  ariaDescribedBy,
+}: FieldProps<TFieldValues, Record<string, unknown> | Record<string, unknown>[]>) => {
+  const form = useFormContext<TFieldValues>();
+  const resolvedControl: Control<TFieldValues> | undefined = control ?? form?.control;
+
+  if (!resolvedControl) {
+    throw new Error('RepeaterField requires a react-hook-form control.');
+  }
+
+  const {
+    fields: configuredFields = [],
+    itemLabel = DEFAULT_ITEM_LABEL,
+    addButtonLabel,
+    removeButtonLabel,
+    moveUpLabel,
+    moveDownLabel,
+    emptyStateText = DEFAULT_EMPTY_TEXT,
+    minItems,
+    maxItems,
+    defaultItemValue,
+  } = (componentProps ?? {}) as RepeaterComponentProps;
+
+  const liveRegionRef = React.useRef<HTMLDivElement | null>(null);
+  const resetTimerRef = React.useRef<number | undefined>(undefined);
+
+  const announce = React.useCallback((message: string) => {
+    const region = liveRegionRef.current;
+    if (!region) {
+      return;
+    }
+
+    region.textContent = message;
+
+    if (typeof window !== 'undefined') {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = window.setTimeout(() => {
+        if (region.textContent === message) {
+          region.textContent = '';
+        }
+      }, ANNOUNCEMENT_RESET_DELAY);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const normalizedItemConfigs = React.useMemo(
+    () =>
+      Array.isArray(configuredFields)
+        ? configuredFields.filter((config): config is RepeaterItemConfig =>
+            Boolean(config?.name && config?.component),
+          )
+        : [],
+    [configuredFields],
+  );
+
+  const defaultItem = React.useMemo(
+    () => buildDefaultItem(normalizedItemConfigs, defaultItemValue),
+    [defaultItemValue, normalizedItemConfigs],
+  );
+
+  const fieldArray = useFieldArray<TFieldValues, ArrayPath<TFieldValues>>({
+    name: name as ArrayPath<TFieldValues>,
+    control: resolvedControl,
+  });
+
+  const { fields, append, remove, move } = fieldArray;
+
+  React.useEffect(() => {
+    if (typeof minItems !== 'number' || minItems <= 0) {
+      return;
+    }
+
+    if (fields.length >= minItems) {
+      return;
+    }
+
+    const missing = minItems - fields.length;
+    for (let index = 0; index < missing; index += 1) {
+      append(defaultItem as FieldArray<TFieldValues, ArrayPath<TFieldValues>>);
+    }
+  }, [append, defaultItem, fields.length, minItems]);
+
+  React.useEffect(() => {
+    if (typeof maxItems !== 'number' || maxItems <= 0) {
+      return;
+    }
+
+    if (fields.length <= maxItems) {
+      return;
+    }
+
+    const overflow = fields.length - maxItems;
+    const indexesToRemove = Array.from({ length: overflow }, (_, position) => maxItems + position);
+    remove(indexesToRemove);
+  }, [fields.length, maxItems, remove]);
+
+  const canAdd =
+    !disabled && !readOnly && (typeof maxItems !== 'number' || fields.length < maxItems);
+  const canRemove =
+    !disabled && !readOnly && (typeof minItems !== 'number' || fields.length > minItems);
+  const canReorder = !disabled && !readOnly && fields.length > 1;
+
+  const handleAdd = React.useCallback(() => {
+    if (!canAdd) {
+      return;
+    }
+
+    append(defaultItem as FieldArray<TFieldValues, ArrayPath<TFieldValues>>);
+    announce(`${itemLabel} ${fields.length + 1} added.`);
+  }, [announce, append, canAdd, defaultItem, fields.length, itemLabel]);
+
+  const handleRemove = React.useCallback(
+    (index: number) => {
+      if (!canRemove) {
+        return;
+      }
+
+      remove(index);
+      announce(`${itemLabel} ${index + 1} removed.`);
+    },
+    [announce, canRemove, itemLabel, remove],
+  );
+
+  const handleMove = React.useCallback(
+    (from: number, to: number) => {
+      if (!canReorder) {
+        return;
+      }
+
+      move(from, to);
+      announce(`${itemLabel} ${from + 1} moved to position ${to + 1}.`);
+    },
+    [announce, canReorder, itemLabel, move],
+  );
+
+  const getNestedError = React.useCallback(
+    (fieldName: string) => {
+      if (!form) {
+        return undefined;
+      }
+
+      const fieldState = form.getFieldState(fieldName as Path<TFieldValues>, form.formState);
+      return getErrorMessage(fieldState.error);
+    },
+    [form],
+  );
+
+  const addLabel = addButtonLabel ?? `Add ${itemLabel}`;
+  const removeLabel = removeButtonLabel ?? DEFAULT_REMOVE_LABEL;
+  const moveUpButtonLabel = moveUpLabel ?? DEFAULT_MOVE_UP_LABEL;
+  const moveDownButtonLabel = moveDownLabel ?? DEFAULT_MOVE_DOWN_LABEL;
+
+  return (
+    <div className={cn('space-y-4', className)} data-repeater>
+      <div aria-live="polite" aria-atomic="true" className="sr-only" ref={liveRegionRef} />
+
+      {fields.length === 0 ? (
+        <div className="rounded-md border border-dashed border-muted-foreground/40 p-4 text-sm text-muted-foreground">
+          {emptyStateText}
+        </div>
+      ) : (
+        <ul className="space-y-4" role="list">
+          {fields.map((field: FieldArrayWithId<TFieldValues, ArrayPath<TFieldValues>>, index) => {
+            const itemNumber = index + 1;
+
+            return (
+              <li
+                key={field.id}
+                className="rounded-md border border-border bg-muted/10 p-4 shadow-sm"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <p className="text-sm font-medium text-foreground">
+                    {itemLabel} {itemNumber}
+                  </p>
+
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="rounded-md border border-input px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={() => handleRemove(index)}
+                      disabled={!canRemove}
+                    >
+                      {removeLabel}
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-md border border-input px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={() => handleMove(index, index - 1)}
+                      disabled={!canReorder || index === 0}
+                      aria-label={`${moveUpButtonLabel} ${itemLabel} ${itemNumber}`}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-md border border-input px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={() => handleMove(index, index + 1)}
+                      disabled={!canReorder || index === fields.length - 1}
+                      aria-label={`${moveDownButtonLabel} ${itemLabel} ${itemNumber}`}
+                    >
+                      ↓
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-4">
+                  {normalizedItemConfigs.map((config) => {
+                    const {
+                      component,
+                      name: itemFieldName,
+                      label,
+                      placeholder,
+                      description,
+                      helpText,
+                      className: itemClassName,
+                      options,
+                      disabled: itemDisabled,
+                      readOnly: itemReadOnly,
+                      required,
+                      ...restComponentProps
+                    } = config;
+
+                    const fieldName = `${name}.${index}.${itemFieldName}`;
+                    const nestedError = getNestedError(fieldName);
+
+                    return (
+                      <FieldFactory
+                        key={`${field.id}-${itemFieldName}`}
+                        name={fieldName}
+                        widget={component}
+                        label={label}
+                        placeholder={placeholder}
+                        description={description}
+                        helpText={helpText}
+                        className={itemClassName as string | undefined}
+                        disabled={disabled || itemDisabled}
+                        readOnly={readOnly || itemReadOnly}
+                        required={required}
+                        control={resolvedControl as unknown as Control<FieldValues>}
+                        options={options}
+                        componentProps={restComponentProps as Record<string, unknown>}
+                        error={nestedError}
+                      />
+                    );
+                  })}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div>
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleAdd}
+          disabled={!canAdd}
+          aria-describedby={ariaDescribedBy}
+        >
+          {addLabel}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+RepeaterField.displayName = 'RepeaterField';

--- a/packages/form-engine/src/components/fields/specialized/PostcodeField.tsx
+++ b/packages/form-engine/src/components/fields/specialized/PostcodeField.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import * as React from 'react';
+import { Controller, type FieldValues } from 'react-hook-form';
+
+import { cn } from '../../../utils/cn';
+import type { FocusEvt, InputChange } from '../../../types/events';
+import type { FieldProps } from '../types';
+
+export type PostcodeFieldProps<TFieldValues extends FieldValues = FieldValues> = FieldProps<
+  TFieldValues,
+  string | null
+> & {
+  autoFormat?: boolean;
+};
+
+type PostcodeComponentProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  autoFormat?: boolean;
+};
+
+const POSTCODE_PATTERN = '^[A-Za-z]{1,2}\\d[A-Za-z\\d]? ?\\d[A-Za-z]{2}$';
+
+const normalizePostcode = (value: string): string =>
+  value
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+    .slice(0, 7);
+
+const formatPostcode = (value: string, autoFormat: boolean): string => {
+  const normalized = normalizePostcode(value);
+  if (!normalized) {
+    return '';
+  }
+
+  if (!autoFormat || normalized.length <= 3) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, normalized.length - 3)} ${normalized.slice(-3)}`;
+};
+
+export const PostcodeField: React.FC<PostcodeFieldProps> = (props) => {
+  const {
+    id,
+    name,
+    control,
+    rules,
+    disabled,
+    readOnly,
+    placeholder,
+    onChange,
+    onValueChange,
+    onStringChange,
+    onBlur,
+    onFocus,
+    className,
+    defaultValue,
+    value,
+    ariaDescribedBy,
+    ariaInvalid,
+    ariaRequired,
+    componentProps,
+    autoFormat,
+  } = props;
+
+  const fieldId = id ?? name;
+  const { autoFormat: componentAutoFormat, ...restComponentProps } = (componentProps ??
+    {}) as PostcodeComponentProps;
+
+  const shouldAutoFormat =
+    typeof autoFormat === 'boolean'
+      ? autoFormat
+      : typeof componentAutoFormat === 'boolean'
+        ? componentAutoFormat
+        : true;
+
+  const resolvedComponentProps = restComponentProps;
+  const hasExternalValue = value !== undefined;
+
+  const emitValue = React.useCallback(
+    (nextValue: string) => {
+      onChange?.(nextValue);
+      onValueChange?.(nextValue);
+      onStringChange?.(nextValue);
+    },
+    [onChange, onStringChange, onValueChange],
+  );
+
+  const initialValue = hasExternalValue
+    ? ((value as string | null | undefined) ?? '')
+    : ((defaultValue as string | null | undefined) ?? '');
+
+  const formattedInitial = React.useMemo(
+    () => formatPostcode(initialValue, shouldAutoFormat),
+    [initialValue, shouldAutoFormat],
+  );
+
+  const [internalValue, setInternalValue] = React.useState<string>(formattedInitial);
+
+  React.useEffect(() => {
+    if (hasExternalValue) {
+      setInternalValue(
+        formatPostcode((value as string | null | undefined) ?? '', shouldAutoFormat),
+      );
+    }
+  }, [hasExternalValue, shouldAutoFormat, value]);
+
+  React.useEffect(() => {
+    if (!hasExternalValue) {
+      setInternalValue(formatPostcode(initialValue, shouldAutoFormat));
+    }
+  }, [hasExternalValue, initialValue, shouldAutoFormat]);
+
+  const handleBlur = React.useCallback(
+    (event: FocusEvt) => {
+      onBlur?.(event);
+    },
+    [onBlur],
+  );
+
+  const handleFocus = React.useCallback(
+    (event: FocusEvt) => {
+      onFocus?.(event);
+    },
+    [onFocus],
+  );
+
+  const renderInput = (
+    currentValue: string,
+    onValueUpdate: (next: string) => void,
+    invalid: boolean | undefined,
+  ) => (
+    <input
+      {...resolvedComponentProps}
+      id={fieldId}
+      name={name}
+      type="text"
+      inputMode={resolvedComponentProps.inputMode ?? 'text'}
+      autoComplete={resolvedComponentProps.autoComplete ?? 'postal-code'}
+      maxLength={resolvedComponentProps.maxLength ?? 8}
+      pattern={resolvedComponentProps.pattern ?? POSTCODE_PATTERN}
+      value={currentValue}
+      placeholder={placeholder ?? resolvedComponentProps.placeholder}
+      disabled={disabled || resolvedComponentProps.disabled}
+      readOnly={readOnly}
+      aria-describedby={ariaDescribedBy}
+      aria-invalid={invalid}
+      aria-required={ariaRequired}
+      className={cn(
+        'block w-full rounded-md border px-3 py-2 text-sm',
+        className,
+        invalid && 'border-destructive',
+      )}
+      onChange={(event: InputChange) => {
+        const next = formatPostcode(event.target.value, shouldAutoFormat);
+        onValueUpdate(next);
+      }}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+    />
+  );
+
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        defaultValue={formattedInitial}
+        render={({ field, fieldState }) => {
+          const fieldValue = typeof field.value === 'string' ? field.value : '';
+          const nextValue = formatPostcode(fieldValue, shouldAutoFormat);
+          return renderInput(
+            nextValue,
+            (updatedValue) => {
+              field.onChange(updatedValue);
+              emitValue(updatedValue);
+            },
+            ariaInvalid ?? Boolean(fieldState.error),
+          );
+        }}
+      />
+    );
+  }
+
+  return renderInput(
+    hasExternalValue
+      ? formatPostcode((value as string | null | undefined) ?? '', shouldAutoFormat)
+      : internalValue,
+    (nextValue) => {
+      if (!hasExternalValue) {
+        setInternalValue(nextValue);
+      }
+      emitValue(nextValue);
+    },
+    ariaInvalid,
+  );
+};

--- a/packages/form-engine/src/core/field-registry.ts
+++ b/packages/form-engine/src/core/field-registry.ts
@@ -11,9 +11,11 @@ import { TextField } from '../components/fields/TextField';
 import { RadioGroupField } from '../components/fields/RadioGroupField';
 import { RatingField } from '../components/fields/RatingField';
 import { SliderField } from '../components/fields/SliderField';
+import { RepeaterField } from '../components/fields/RepeaterField';
 import { CurrencyField } from '../components/fields/specialized/CurrencyField';
 import { EmailField } from '../components/fields/specialized/EmailField';
 import { PhoneField } from '../components/fields/specialized/PhoneField';
+import { PostcodeField } from '../components/fields/specialized/PostcodeField';
 import type { WidgetType } from '../types';
 
 export interface FieldComponent<TProps extends FieldProps = FieldProps> {
@@ -82,11 +84,13 @@ export function initializeFieldRegistry(): FieldRegistry {
       ['Checkbox', { component: CheckboxField as unknown as React.ComponentType<FieldProps> }],
       ['Date', { component: DateField as unknown as React.ComponentType<FieldProps> }],
       ['RadioGroup', { component: RadioGroupField as unknown as React.ComponentType<FieldProps> }],
+      ['Repeater', { component: RepeaterField as unknown as React.ComponentType<FieldProps> }],
       ['FileUpload', { component: FileUploadField as unknown as React.ComponentType<FieldProps> }],
       ['Slider', { component: SliderField as unknown as React.ComponentType<FieldProps> }],
       ['Rating', { component: RatingField as unknown as React.ComponentType<FieldProps> }],
       ['Currency', { component: CurrencyField as unknown as React.ComponentType<FieldProps> }],
       ['Phone', { component: PhoneField as unknown as React.ComponentType<FieldProps> }],
+      ['Postcode', { component: PostcodeField as unknown as React.ComponentType<FieldProps> }],
       ['Email', { component: EmailField as unknown as React.ComponentType<FieldProps> }],
     ];
 

--- a/packages/form-engine/src/types/ui.types.ts
+++ b/packages/form-engine/src/types/ui.types.ts
@@ -45,10 +45,37 @@ export interface WidgetConfig {
   optionsFrom?: string;
   mask?: string;
   format?: string;
+  autoFormat?: boolean;
   min?: number;
   max?: number;
   step?: number;
   emptyValue?: unknown;
+  fields?: RepeaterItemConfig[];
+  itemLabel?: string;
+  addButtonLabel?: string;
+  removeButtonLabel?: string;
+  moveUpLabel?: string;
+  moveDownLabel?: string;
+  emptyStateText?: string;
+  minItems?: number;
+  maxItems?: number;
+  defaultItemValue?: Record<string, unknown>;
+}
+
+export interface RepeaterItemConfig {
+  name: string;
+  component: WidgetType;
+  label?: string;
+  placeholder?: string;
+  description?: string;
+  helpText?: string;
+  className?: string;
+  options?: Array<{ label: string; value: string | number }>;
+  disabled?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  defaultValue?: unknown;
+  [key: string]: unknown;
 }
 
 export interface WidgetStyleRule {

--- a/packages/form-engine/src/utils/schema-validator.ts
+++ b/packages/form-engine/src/utils/schema-validator.ts
@@ -1,12 +1,7 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 
-import type {
-  CompiledSchema,
-  JSONSchema,
-  UnifiedFormSchema,
-  ValidationResult
-} from '../types';
+import type { CompiledSchema, JSONSchema, UnifiedFormSchema, ValidationResult } from '../types';
 
 const UNIFIED_SCHEMA_META: JSONSchema = {
   $id: 'https://schemas.cml.local/unified-form-schema.json',
@@ -17,7 +12,7 @@ const UNIFIED_SCHEMA_META: JSONSchema = {
     version: { type: 'string' },
     extends: {
       type: 'array',
-      items: { type: 'string' }
+      items: { type: 'string' },
     },
     metadata: {
       type: 'object',
@@ -27,21 +22,21 @@ const UNIFIED_SCHEMA_META: JSONSchema = {
         description: { type: 'string' },
         sensitivity: {
           type: 'string',
-          enum: ['low', 'medium', 'high']
+          enum: ['low', 'medium', 'high'],
         },
         retainHidden: { type: 'boolean' },
         allowAutosave: { type: 'boolean' },
         timeout: { type: 'number' },
         tags: {
           type: 'array',
-          items: { type: 'string' }
+          items: { type: 'string' },
         },
         owner: { type: 'string' },
-        lastModified: { type: 'string' }
-      }
+        lastModified: { type: 'string' },
+      },
     },
     definitions: {
-      type: 'object'
+      type: 'object',
     },
     steps: {
       type: 'array',
@@ -62,13 +57,13 @@ const UNIFIED_SCHEMA_META: JSONSchema = {
                 type: 'object',
                 required: ['$ref'],
                 properties: {
-                  $ref: { type: 'string' }
-                }
-              }
-            ]
-          }
-        }
-      }
+                  $ref: { type: 'string' },
+                },
+              },
+            ],
+          },
+        },
+      },
     },
     transitions: {
       type: 'array',
@@ -79,9 +74,9 @@ const UNIFIED_SCHEMA_META: JSONSchema = {
           from: { type: 'string' },
           to: { type: 'string' },
           when: { type: 'object' },
-          default: { type: 'boolean' }
-        }
-      }
+          default: { type: 'boolean' },
+        },
+      },
     },
     ui: { type: 'object' },
     computed: {
@@ -95,16 +90,16 @@ const UNIFIED_SCHEMA_META: JSONSchema = {
           dependsOn: {
             type: 'array',
             minItems: 1,
-            items: { type: 'string' }
-          }
-        }
-      }
+            items: { type: 'string' },
+          },
+        },
+      },
     },
     dataSources: {
-      type: 'object'
-    }
+      type: 'object',
+    },
   },
-  additionalProperties: true
+  additionalProperties: true,
 };
 
 export class SchemaValidator {
@@ -115,7 +110,7 @@ export class SchemaValidator {
       allErrors: true,
       verbose: true,
       strict: true,
-      validateFormats: true
+      validateFormats: true,
     });
 
     addFormats(this.ajv);
@@ -127,24 +122,31 @@ export class SchemaValidator {
   private registerCustomFormats(): void {
     this.ajv.addFormat('phone', {
       type: 'string',
-      validate: (data: string) => /^\+?[1-9]\d{1,14}$/.test(data)
+      validate: (data: string) => /^\+?[1-9]\d{1,14}$/.test(data),
+    });
+
+    const postcodeValidator = (data: string) =>
+      /^[A-Z]{1,2}[0-9]{1,2}[A-Z]?\s?[0-9][A-Z]{2}$/i.test(data.trim());
+
+    this.ajv.addFormat('gb-postcode', {
+      type: 'string',
+      validate: postcodeValidator,
     });
 
     this.ajv.addFormat('postcode', {
       type: 'string',
-      validate: (data: string) =>
-        /^[A-Z]{1,2}[0-9]{1,2}[A-Z]?\s?[0-9][A-Z]{2}$/i.test(data)
+      validate: postcodeValidator,
     });
 
     this.ajv.addFormat('iban', {
       type: 'string',
       validate: (data: string) =>
-        /^[A-Z]{2}[0-9]{2}[A-Z0-9]{4}[0-9]{7}([A-Z0-9]?){0,16}$/.test(data)
+        /^[A-Z]{2}[0-9]{2}[A-Z0-9]{4}[0-9]{7}([A-Z0-9]?){0,16}$/.test(data),
     });
 
     this.ajv.addFormat('currency', {
       type: 'string',
-      validate: (data: string) => /^\d+(\.\d{1,2})?$/.test(data)
+      validate: (data: string) => /^\d+(\.\d{1,2})?$/.test(data),
     });
   }
 
@@ -163,9 +165,7 @@ export class SchemaValidator {
           };
           if (!field) return true;
           if (data[field] === equals) {
-            const required: string[] = Array.isArray(schema.requires)
-              ? schema.requires
-              : [];
+            const required: string[] = Array.isArray(schema.requires) ? schema.requires : [];
             for (const requiredField of required) {
               if (
                 data[requiredField] === undefined ||
@@ -178,8 +178,8 @@ export class SchemaValidator {
                     schemaPath: '#/requiredWhen',
                     keyword: 'requiredWhen',
                     params: { missingProperty: requiredField },
-                    message: `${requiredField} is required`
-                  }
+                    message: `${requiredField} is required`,
+                  },
                 ];
                 return false;
               }
@@ -189,7 +189,7 @@ export class SchemaValidator {
         };
 
         return validator;
-      }
+      },
     });
   }
 
@@ -202,11 +202,12 @@ export class SchemaValidator {
         path: error.instancePath,
         message: error.message || 'Schema validation error',
         keyword: error.keyword,
-        property: error.params && 'missingProperty' in error.params
-          ? String(error.params.missingProperty)
-          : undefined,
-        params: error.params as Record<string, unknown>
-      }))
+        property:
+          error.params && 'missingProperty' in error.params
+            ? String(error.params.missingProperty)
+            : undefined,
+        params: error.params as Record<string, unknown>,
+      })),
     };
   }
 

--- a/packages/form-engine/src/validation/ajv-setup.ts
+++ b/packages/form-engine/src/validation/ajv-setup.ts
@@ -50,9 +50,17 @@ export class ValidationEngine {
   }
 
   private registerCustomFormats(): void {
+    const postcodeValidator = (data: string) =>
+      /^[A-Z]{1,2}[0-9][A-Z0-9]?\s?[0-9][A-Z]{2}$/i.test(data.trim());
+
+    this.ajv.addFormat('gb-postcode', {
+      type: 'string',
+      validate: postcodeValidator,
+    });
+
     this.ajv.addFormat('uk-postcode', {
       type: 'string',
-      validate: (data: string) => /^[A-Z]{1,2}[0-9][A-Z0-9]?\s?[0-9][A-Z]{2}$/i.test(data.trim()),
+      validate: postcodeValidator,
     });
 
     this.ajv.addFormat('us-zip', {

--- a/packages/form-engine/tests/unit/FormRenderer.test.tsx
+++ b/packages/form-engine/tests/unit/FormRenderer.test.tsx
@@ -1,8 +1,38 @@
 import * as React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { UnifiedFormSchema } from '@form-engine/types';
 import { FormRenderer } from '@form-engine/index';
+
+const saveDraftMock = jest.fn();
+const flushPendingSavesMock = jest.fn();
+const loadDraftMock = jest.fn();
+const deleteDraftMock = jest.fn();
+
+jest.mock('../../src/persistence/PersistenceManager', () => ({
+  PersistenceManager: jest.fn().mockImplementation(() => ({
+    saveDraft: saveDraftMock,
+    flushPendingSaves: flushPendingSavesMock,
+    loadDraft: loadDraftMock,
+    deleteDraft: deleteDraftMock,
+  })),
+}));
+
+const { PersistenceManager } = jest.requireMock('../../src/persistence/PersistenceManager') as {
+  PersistenceManager: jest.Mock;
+};
+
+beforeEach(() => {
+  saveDraftMock.mockReset();
+  flushPendingSavesMock.mockReset();
+  loadDraftMock.mockReset();
+  deleteDraftMock.mockReset();
+  PersistenceManager.mockClear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 const buildSchema = (): UnifiedFormSchema => ({
   $id: 'test-form',
@@ -169,6 +199,343 @@ describe('FormRenderer', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Conditional Step')).toBeInTheDocument();
+    });
+  });
+
+  it('handles repeater fields and submits array data', async () => {
+    const schema: UnifiedFormSchema = {
+      $id: 'repeater-form',
+      version: '1.0.0',
+      metadata: {
+        title: 'Repeater Form',
+        description: 'Test form with repeater field',
+        sensitivity: 'low',
+      },
+      steps: [
+        {
+          id: 'household',
+          title: 'Household',
+          schema: {
+            type: 'object',
+            properties: {
+              references: {
+                type: 'array',
+                minItems: 1,
+                maxItems: 3,
+                items: {
+                  type: 'object',
+                  properties: {
+                    fullName: { type: 'string', minLength: 1 },
+                    email: { type: 'string', format: 'email' },
+                  },
+                  required: ['fullName', 'email'],
+                },
+              },
+            },
+            required: ['references'],
+          },
+        },
+      ],
+      transitions: [],
+      ui: {
+        widgets: {
+          references: {
+            component: 'Repeater',
+            label: 'References',
+            itemLabel: 'Reference',
+            minItems: 1,
+            maxItems: 3,
+            addButtonLabel: 'Add reference',
+            removeButtonLabel: 'Remove reference',
+            fields: [
+              { name: 'fullName', component: 'Text', label: 'Full name', required: true },
+              { name: 'email', component: 'Email', label: 'Email address', required: true },
+            ],
+          },
+        },
+      },
+    };
+
+    const onSubmit = jest.fn();
+    render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+    expect(await screen.findByText(/reference 1/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getAllByRole('alert').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.change(screen.getByRole('textbox', { name: /full name/i }), {
+      target: { value: 'Test Reference' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /email address/i }), {
+      target: { value: 'ref@example.com' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          references: [
+            expect.objectContaining({
+              fullName: 'Test Reference',
+              email: 'ref@example.com',
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('validates and formats postcode input using the specialised widget', async () => {
+    const schema: UnifiedFormSchema = {
+      $id: 'postcode-form',
+      version: '1.0.0',
+      metadata: {
+        title: 'Postcode Form',
+        description: 'Test form with postcode field',
+        sensitivity: 'low',
+      },
+      steps: [
+        {
+          id: 'address',
+          title: 'Address',
+          schema: {
+            type: 'object',
+            properties: {
+              postcode: { type: 'string', format: 'gb-postcode' },
+            },
+            required: ['postcode'],
+          },
+        },
+      ],
+      transitions: [],
+      ui: {
+        widgets: {
+          postcode: { component: 'Postcode', label: 'Postcode' },
+        },
+      },
+    };
+
+    const onSubmit = jest.fn();
+    render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+    const input = await screen.findByRole('textbox', { name: /postcode/i });
+
+    fireEvent.change(input, { target: { value: 'invalid' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThan(0);
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: 'sw1a1aa' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postcode: 'SW1A 1AA',
+      }),
+    );
+  });
+
+  it('retries submission with exponential backoff on retryable errors', async () => {
+    jest.useFakeTimers();
+    try {
+      const schema = buildSchema();
+      const onSubmit = jest
+        .fn()
+        .mockRejectedValueOnce({ status: 500 })
+        .mockRejectedValueOnce({ response: { status: 429 } })
+        .mockResolvedValue(undefined);
+
+      render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+      fireEvent.change(await screen.findByRole('textbox', { name: /first name/i }), {
+        target: { value: 'Retry' },
+      });
+      fireEvent.change(await screen.findByRole('textbox', { name: /last name/i }), {
+        target: { value: 'Tester' },
+      });
+
+      fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {
+          target: { value: 'retry@example.com' },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+      });
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      expect(
+        screen.getByText(/submission failed \(attempt 1 of 3\)\. retrying/i),
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+      });
+
+      expect(
+        screen.getByText(/submission failed \(attempt 2 of 3\)\. retrying/i),
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(3);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText(/retrying/i)).not.toBeInTheDocument();
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('saves a draft and surfaces a message after exhausting retries', async () => {
+    jest.useFakeTimers();
+    try {
+      const schema = buildSchema();
+      const onSubmit = jest.fn().mockRejectedValue({ status: 500 });
+
+      render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+      fireEvent.change(await screen.findByRole('textbox', { name: /first name/i }), {
+        target: { value: 'Draft' },
+      });
+      fireEvent.change(await screen.findByRole('textbox', { name: /last name/i }), {
+        target: { value: 'Saver' },
+      });
+
+      fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {
+          target: { value: 'draft@example.com' },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+      });
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(3);
+      });
+
+      await waitFor(() => {
+        expect(saveDraftMock).toHaveBeenCalledTimes(1);
+        expect(flushPendingSavesMock).toHaveBeenCalledTimes(1);
+      });
+
+      const [, , , options] = saveDraftMock.mock.calls[0];
+      expect(options).toMatchObject({ manual: true, immediate: true });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/your progress was saved so you can try again shortly/i),
+        ).toBeInTheDocument();
+      });
+
+      expect(PersistenceManager).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('locks controls when the session expires and supports restarting', async () => {
+    jest.useFakeTimers();
+
+    const schema = buildSchema();
+    schema.metadata.timeout = 0.02;
+
+    render(<FormRenderer schema={schema} onSubmit={jest.fn()} />);
+
+    expect(await screen.findByText(/session expires in/i)).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /start new session/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /start new session/i }));
+
+    await waitFor(() => {
+      expect(deleteDraftMock).toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: /^next$/i })).not.toBeDisabled();
+      expect(screen.getByText(/started a new session/i)).toBeInTheDocument();
+    });
+  });
+
+  it('restores saved progress after session expiry when a draft exists', async () => {
+    jest.useFakeTimers();
+
+    const schema = buildSchema();
+    schema.metadata.timeout = 0.02;
+
+    loadDraftMock.mockResolvedValueOnce({
+      data: { firstName: 'Saved', lastName: 'User', email: 'saved@example.com' },
+      currentStep: 'contact',
+      completedSteps: ['personal'],
+    });
+
+    render(<FormRenderer schema={schema} onSubmit={jest.fn()} />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    const restoreButton = await screen.findByRole('button', { name: /restore saved draft/i });
+
+    fireEvent.click(restoreButton);
+
+    await waitFor(() => {
+      expect(loadDraftMock).toHaveBeenCalled();
+      expect(screen.getByText(/restored your saved progress/i)).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue('saved@example.com');
     });
   });
 });

--- a/packages/form-engine/tests/unit/PostcodeField.test.tsx
+++ b/packages/form-engine/tests/unit/PostcodeField.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { PostcodeField } from '../../src/components/fields/specialized/PostcodeField';
+
+describe('PostcodeField', () => {
+  it('auto formats input values and notifies handlers', () => {
+    const handleChange = jest.fn();
+    const handleValueChange = jest.fn();
+
+    render(
+      <PostcodeField name="postcode" onChange={handleChange} onValueChange={handleValueChange} />,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'sw1a1aa' } });
+
+    expect(input).toHaveValue('SW1A 1AA');
+    expect(handleChange).toHaveBeenCalledWith('SW1A 1AA');
+    expect(handleValueChange).toHaveBeenCalledWith('SW1A 1AA');
+  });
+
+  it('supports disabling auto format via prop', () => {
+    render(<PostcodeField name="postcode" autoFormat={false} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'sw1a1aa' } });
+
+    expect(input).toHaveValue('SW1A1AA');
+  });
+
+  it('works with react-hook-form control and submits formatted values', async () => {
+    const handleSubmit = jest.fn();
+
+    const TestForm: React.FC = () => {
+      const methods = useForm<{ postcode: string }>({ defaultValues: { postcode: '' } });
+
+      return (
+        <FormProvider {...methods}>
+          <form onSubmit={methods.handleSubmit(handleSubmit)}>
+            <PostcodeField name="postcode" control={methods.control} />
+            <button type="submit">Submit</button>
+          </form>
+        </FormProvider>
+      );
+    };
+
+    render(<TestForm />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'ec1a1bb' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(handleSubmit.mock.calls[0]?.[0]).toEqual({ postcode: 'EC1A 1BB' });
+  });
+});

--- a/packages/form-engine/tests/unit/RepeaterField.test.tsx
+++ b/packages/form-engine/tests/unit/RepeaterField.test.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
+
+import { FieldRegistry, initializeFieldRegistry } from '@form-engine/index';
+import { RepeaterField } from '@form-engine/components/fields/RepeaterField';
+
+type FormValues = {
+  references: Array<{ fullName?: string; email?: string }>;
+};
+
+describe('RepeaterField', () => {
+  beforeEach(() => {
+    FieldRegistry.reset();
+    initializeFieldRegistry();
+  });
+
+  const Wrapper: React.FC<{
+    defaultValues?: FormValues;
+    onReady?: (methods: UseFormReturn<FormValues>) => void;
+  }> = ({ defaultValues, onReady }) => {
+    const methods = useForm<FormValues>({ defaultValues });
+
+    React.useEffect(() => {
+      onReady?.(methods);
+    }, [methods, onReady]);
+
+    return (
+      <FormProvider {...methods}>
+        <RepeaterField
+          name="references"
+          label="References"
+          control={methods.control}
+          componentProps={{
+            itemLabel: 'Reference',
+            minItems: 1,
+            maxItems: 2,
+            addButtonLabel: 'Add reference',
+            removeButtonLabel: 'Remove reference',
+            fields: [
+              { name: 'fullName', component: 'Text', label: 'Full name', required: true },
+              { name: 'email', component: 'Email', label: 'Email address', required: true },
+            ],
+          }}
+        />
+      </FormProvider>
+    );
+  };
+
+  it('renders the minimum number of items on mount and blocks removal when at min', async () => {
+    render(<Wrapper defaultValues={{ references: [] }} />);
+
+    expect(await screen.findByText(/^Reference 1$/i)).toBeInTheDocument();
+    const removeButtons = screen.getAllByRole('button', { name: /remove reference/i });
+    fireEvent.click(removeButtons[0]);
+
+    expect(await screen.findByText(/^Reference 1$/i)).toBeInTheDocument();
+  });
+
+  it('adds and removes items within min/max bounds', async () => {
+    render(<Wrapper defaultValues={{ references: [] }} />);
+
+    const addButton = await screen.findByRole('button', { name: /add reference/i });
+    fireEvent.click(addButton);
+
+    expect(await screen.findByText(/^Reference 2$/i)).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+
+    const removeButtons = screen.getAllByRole('button', { name: /remove reference/i });
+    fireEvent.click(removeButtons[1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/^Reference 2$/i)).not.toBeInTheDocument();
+    });
+    expect(addButton).not.toBeDisabled();
+  });
+
+  it('reorders items when move controls are used', async () => {
+    render(
+      <Wrapper
+        defaultValues={{
+          references: [
+            { fullName: 'Alice Example', email: 'alice@example.com' },
+            { fullName: 'Brian Example', email: 'brian@example.com' },
+          ],
+        }}
+      />,
+    );
+
+    const moveDownButton = await screen.findByRole('button', {
+      name: /move down reference 1/i,
+    });
+    fireEvent.click(moveDownButton);
+
+    const nameInputs = await screen.findAllByRole('textbox', { name: /full name/i });
+    expect(nameInputs[0]).toHaveValue('Brian Example');
+  });
+
+  it('surfaces nested validation errors', async () => {
+    let methodsRef: UseFormReturn<FormValues> | undefined;
+
+    render(
+      <Wrapper
+        defaultValues={{ references: [{}] }}
+        onReady={(methods) => {
+          methodsRef = methods;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      methodsRef?.setError('references.0.fullName', {
+        type: 'required',
+        message: 'Required field',
+      });
+    });
+
+    expect(await screen.findByText(/required field/i)).toBeInTheDocument();
+  });
+});

--- a/packages/form-engine/tests/unit/field-registry.test.tsx
+++ b/packages/form-engine/tests/unit/field-registry.test.tsx
@@ -52,4 +52,16 @@ describe('FieldRegistry', () => {
     rerender(<FieldFactory widget="Custom" name="custom" label="Override" />);
     expect(screen.getByText('Override')).toBeInTheDocument();
   });
+
+  it('initializes repeater field in the default registry', () => {
+    const registry = FieldRegistry.getInstance();
+    const repeater = registry.get('Repeater');
+    expect(repeater).toBeDefined();
+  });
+
+  it('initializes postcode field in the default registry', () => {
+    const registry = FieldRegistry.getInstance();
+    const postcode = registry.get('Postcode');
+    expect(postcode).toBeDefined();
+  });
 });

--- a/src/demo/DemoFormSchema.ts
+++ b/src/demo/DemoFormSchema.ts
@@ -8,6 +8,7 @@ export const demoFormSchema: UnifiedFormSchema = {
     description:
       'Comprehensive job application demonstrating validation, branching, and persistence.',
     sensitivity: 'high',
+    timeout: 30,
     allowAutosave: true,
     retainHidden: false,
     requiresAudit: true,
@@ -51,12 +52,16 @@ export const demoFormSchema: UnifiedFormSchema = {
           phone: {
             $ref: '#/definitions/phoneNumber',
           },
+          postcode: {
+            type: 'string',
+            format: 'gb-postcode',
+          },
           dateOfBirth: {
             type: 'string',
             format: 'date',
           },
         },
-        required: ['firstName', 'lastName', 'email', 'dateOfBirth'],
+        required: ['firstName', 'lastName', 'email', 'postcode', 'dateOfBirth'],
       },
     },
     {
@@ -225,7 +230,33 @@ export const demoFormSchema: UnifiedFormSchema = {
               ],
             },
           },
+          references: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 3,
+            items: {
+              type: 'object',
+              properties: {
+                fullName: {
+                  type: 'string',
+                  minLength: 2,
+                  maxLength: 120,
+                },
+                relationship: {
+                  type: 'string',
+                  minLength: 2,
+                  maxLength: 120,
+                },
+                email: {
+                  type: 'string',
+                  format: 'email',
+                },
+              },
+              required: ['fullName', 'relationship', 'email'],
+            },
+          },
         },
+        required: ['jobType', 'remotePreference', 'references'],
       },
     },
     {
@@ -356,6 +387,11 @@ export const demoFormSchema: UnifiedFormSchema = {
         label: 'Phone number',
         placeholder: '+1 202 555 0108',
       },
+      postcode: {
+        component: 'Postcode',
+        label: 'Home postcode',
+        helpText: 'Enter a UK postcode, for example SW1A 1AA.',
+      },
       dateOfBirth: {
         component: 'Date',
         label: 'Date of birth',
@@ -465,6 +501,41 @@ export const demoFormSchema: UnifiedFormSchema = {
       preferredLocation: {
         component: 'Text',
         label: 'Preferred location',
+      },
+      references: {
+        component: 'Repeater',
+        label: 'Professional references',
+        description:
+          'List people who can vouch for your work. We will contact them only after discussing with you.',
+        itemLabel: 'Reference',
+        minItems: 1,
+        maxItems: 3,
+        addButtonLabel: 'Add reference',
+        removeButtonLabel: 'Remove reference',
+        emptyStateText: 'Add at least one reference with contact details.',
+        fields: [
+          {
+            name: 'fullName',
+            component: 'Text',
+            label: 'Full name',
+            placeholder: 'Alex Johnson',
+            required: true,
+          },
+          {
+            name: 'relationship',
+            component: 'Text',
+            label: 'Relationship',
+            placeholder: 'Former manager',
+            required: true,
+          },
+          {
+            name: 'email',
+            component: 'Email',
+            label: 'Email address',
+            placeholder: 'alex.johnson@example.com',
+            required: true,
+          },
+        ],
       },
       workAuthorization: {
         component: 'Checkbox',


### PR DESCRIPTION
## Summary
- wire session timeout tracking into FormRenderer with countdown banner, expiry lockout, and restart/restore flows backed by PersistenceManager
- disable navigation/actions while expired, surface accessible status messaging, and seed the demo schema with a 30 minute timeout example
- expand FormRenderer tests to cover timer expiry, restart, and draft restoration scenarios

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test -- --runInBand
- CI=1 npm run build
- CI=1 npm run size

------
https://chatgpt.com/codex/tasks/task_e_68d114107b10832a8ce86802adc72b3f