### PR TITLE
feat(nav): deterministic resolver (P3-NAV-02)

### DIFF
--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -6,7 +6,7 @@
 | P3-01        | Fix P2 regressions (GIR 0AA, repeater, offline)    | P0  | `codex/p3v2-01-regressions`   | _pending_   | In Progress  | ✅ fmt/lint/type/build · ⚠️ test   | Postcode accepts **GIR 0AA**; Repeater focus mgmt added; offline retry WIP tests. |
 | P3-02        | Validation strategy & debounce                     | P0  | `codex/p3v2-02-validation`    | _pending_   | **Merged**   | ✅ fmt/lint/type/test/build/size   | Debounced `onChange` (120ms) + `onBlur` strategy honored; docs updated. |
 | **P3-NAV-01**| Terminal step semantics (resolver)                 | P0  | `codex-form-builder-phase-3`  | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Terminal steps now stay put; awaiting downstream flag wiring. |
-| **P3-NAV-02**| Deterministic resolution (guards/default)          | P0  | `codex/p3v2-nav-02-resolver`  |             | TODO         |                                    |       |
+| **P3-NAV-02**| Deterministic resolution (guards/default)          | P0  | `codex-form-builder-phase-3`  | _pending_   | In Review   | ✅ fmt · ⚠️ lint/type/test/build/size (missing deps) | Deterministic guard-first resolver + default validation; tests added. |
 | **P3-NAV-03**| Review freeze + validation policy                   | P0  | `codex/p3v2-nav-03-review`    |             | TODO         |                                    | `nav.reviewFreeze`, `nav.jumpToFirstInvalidOn` |
 | **P3-NAV-04**| Renderer dedupe/token guard                         | P0  | `codex/p3v2-nav-04-dedupe`    |             | TODO         |                                    |       |
 | **P3-NAV-05**| Schema linter rules (CI blocking)                   | P0  | `codex/p3v2-nav-05-linter`    |             | TODO         |                                    | dup defaults, cycles, unknown targets |
@@ -27,4 +27,4 @@
 
 **Legend:** Status = TODO → In Progress → Review → Merged
 
-_Last updated: 2025-09-24 22:26:29Z_
+_Last updated: 2025-09-24 23:35:38Z


### PR DESCRIPTION
## Summary
- ensure TransitionEngine resolves transitions in declared order with a single default fallback
- throw when schemas define multiple defaults for a single step and cover the scenarios with unit tests
- update PHASE-3 tracker entry for P3-NAV-02 status and notes

## Testing
- npm run format
- npm run lint *(fails: ESLint missing in env)*
- npm run typecheck *(fails: missing optional dependencies and implicit any types in migration stubs)*
- npm run test *(fails: jest not installed in env)*
- npm run build *(fails: missing optional dependencies during typecheck phase)*
- npm run size *(fails: missing optional dependencies during typecheck phase)*

## Checklist
- [x] Deterministic guard evaluation before default fallback
- [x] Reject schemas with multiple defaults per step
- [x] Resolver unit tests cover ordering, fallback, and duplicate defaults


------
https://chatgpt.com/codex/tasks/task_e_68d47f52e650832aa10eee3cd9f7fa35