### PR TITLE
feat(nav): review freeze policy (P3-NAV-03)

### DIFF
--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -8,7 +8,7 @@
 | **P3-NAV-00**| Environment & CI bootstrap                        | P0  | `codex-form-builder-phase-3`  | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Node 20.14 pinned; npm workspaces install + mandatory dev tooling unblocks CI. |
 | **P3-NAV-01**| Terminal step semantics (resolver)                 | P0  | `codex-form-builder-phase-3`  | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Terminal steps now stay put; awaiting downstream flag wiring. |
 | **P3-NAV-02**| Deterministic resolution (guards/default)          | P0  | `codex-form-builder-phase-3`  | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Deterministic guard-first resolver + default validation; tests added. |
-| **P3-NAV-03**| Review freeze + validation policy                   | P0  | `codex/p3v2-nav-03-review`    |             | TODO         |                                    | `nav.reviewFreeze`, `nav.jumpToFirstInvalidOn` |
+| **P3-NAV-03**| Review freeze + validation policy                   | P0  | `codex/p3v2-nav-03-review`    | _pending_   | In Review  | ✅ fmt/lint/type/test/build/size   | Review terminal policy behind `nav.reviewFreeze`; default jump-to-invalid on submit; integration coverage added. |
 | **P3-NAV-04**| Renderer dedupe/token guard                         | P0  | `codex-form-builder-phase-3`  | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | `nav.dedupeToken` gate ignores stale tokens + self-transitions; unit coverage added. |
 | **P3-NAV-05**| Schema linter rules (CI blocking)                   | P0  | `codex/p3v2-nav-05-linter`    |             | TODO         |                                    | dup defaults, cycles, unknown targets |
 | **P3-NAV-06**| Unit tests (resolver)                               | P0  | `codex/p3v2-nav-06-tests`     |             | TODO         |                                    | terminal/null, precedence |
@@ -28,4 +28,4 @@
 
 **Legend:** Status = TODO → In Progress → Review → Merged
 
-_Last updated: 2025-09-25 08:02:41Z
+_Last updated: 2025-09-25 08:48:57Z

--- a/packages/form-engine/src/types/features.types.ts
+++ b/packages/form-engine/src/types/features.types.ts
@@ -1,7 +1,16 @@
-export type FeatureFlagName =
+export type JumpToFirstInvalidMode = 'submit' | 'next' | 'never';
+
+export type BooleanFeatureFlagName =
   | 'gridLayout'
   | 'addressLookupUK'
   | 'reviewSummary'
-  | 'nav.dedupeToken';
+  | 'nav.dedupeToken'
+  | 'nav.reviewFreeze';
 
-export type FeatureFlags = Record<FeatureFlagName, boolean>;
+export type EnumFeatureFlagName = 'nav.jumpToFirstInvalidOn';
+
+export type FeatureFlagName = BooleanFeatureFlagName | EnumFeatureFlagName;
+
+export type FeatureFlags = Record<BooleanFeatureFlagName, boolean> & {
+  'nav.jumpToFirstInvalidOn': JumpToFirstInvalidMode;
+};

--- a/packages/form-engine/src/types/schema.types.ts
+++ b/packages/form-engine/src/types/schema.types.ts
@@ -1,5 +1,5 @@
 import type { ComputedField, DataSourceMap } from './computed.types';
-import type { FeatureFlagName } from './features.types';
+import type { BooleanFeatureFlagName, JumpToFirstInvalidMode } from './features.types';
 import type { JSONSchema } from './json-schema.types';
 import type { Rule, StepTransition } from './rules.types';
 import type { UIDefinition } from './ui.types';
@@ -34,6 +34,18 @@ export interface FormStep {
   helpText?: string;
 }
 
+export interface ReviewNavigationPolicy {
+  stepId?: string;
+  terminal?: boolean;
+  validate?: 'form' | 'step';
+  freezeNavigation?: boolean;
+}
+
+export interface NavigationConfig {
+  review?: ReviewNavigationPolicy;
+  jumpToFirstInvalidOn?: JumpToFirstInvalidMode;
+}
+
 export interface UnifiedFormSchema {
   $id: string;
   version: string;
@@ -46,7 +58,12 @@ export interface UnifiedFormSchema {
   computed?: ComputedField[];
   dataSources?: DataSourceMap;
   validation?: ValidationConfig;
-  features?: Partial<Record<FeatureFlagName, boolean>> & { [key: string]: boolean | undefined };
+  features?:
+    | (Partial<Record<BooleanFeatureFlagName, boolean>> &
+        Partial<Record<'nav.jumpToFirstInvalidOn', JumpToFirstInvalidMode>> &
+        { [key: string]: boolean | string | undefined })
+    | undefined;
+  navigation?: NavigationConfig;
 }
 
 export interface SchemaVersionMeta {

--- a/packages/form-engine/src/utils/schema-validator.ts
+++ b/packages/form-engine/src/utils/schema-validator.ts
@@ -98,6 +98,25 @@ const UNIFIED_SCHEMA_META: JSONSchema = {
     dataSources: {
       type: 'object',
     },
+    navigation: {
+      type: 'object',
+      properties: {
+        review: {
+          type: 'object',
+          properties: {
+            stepId: { type: 'string' },
+            terminal: { type: 'boolean' },
+            validate: { type: 'string', enum: ['form', 'step'] },
+            freezeNavigation: { type: 'boolean' },
+          },
+        },
+        jumpToFirstInvalidOn: {
+          type: 'string',
+          enum: ['submit', 'next', 'never'],
+        },
+      },
+      additionalProperties: true,
+    },
   },
   additionalProperties: true,
 };

--- a/packages/form-engine/tests/integration/navigation.review.integration.test.tsx
+++ b/packages/form-engine/tests/integration/navigation.review.integration.test.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { UnifiedFormSchema } from '@form-engine/types';
+import { FormRenderer } from '@form-engine/index';
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
+  (window as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    ResizeObserverMock as unknown as typeof ResizeObserver;
+}
+
+describe('Review navigation policies', () => {
+  const originalFlags = process.env.NEXT_PUBLIC_FLAGS;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_FLAGS = originalFlags;
+  });
+
+  const reviewStep: UnifiedFormSchema['steps'][number] = {
+    id: 'review',
+    title: 'Review',
+    schema: { type: 'object', properties: {} },
+  };
+
+  const buildSchemaWithConfirmation = (): UnifiedFormSchema => ({
+    $id: 'review-flow',
+    version: '1.0.0',
+    metadata: { title: 'Review Flow', sensitivity: 'low' },
+    steps: [
+      {
+        id: 'details',
+        title: 'Details',
+        schema: {
+          type: 'object',
+          properties: {
+            agree: { type: 'boolean' },
+          },
+        },
+      },
+      reviewStep,
+      { id: 'confirmation', title: 'Confirmation', schema: { type: 'object', properties: {} } },
+    ],
+    transitions: [
+      { from: 'details', to: 'review', default: true },
+      { from: 'review', to: 'confirmation', default: true },
+    ],
+    ui: {
+      widgets: { agree: { component: 'Checkbox', label: 'Agree to terms' } },
+    },
+  });
+
+  const buildSchemaWithValidation = (): UnifiedFormSchema => ({
+    $id: 'review-validation',
+    version: '1.0.0',
+    metadata: { title: 'Validation Flow', sensitivity: 'low' },
+    validation: {
+      strategy: 'onSubmit',
+    },
+    steps: [
+      {
+        id: 'personal',
+        title: 'Personal',
+        schema: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string', minLength: 1 },
+          },
+          required: ['firstName'],
+        },
+      },
+      reviewStep,
+    ],
+    transitions: [{ from: 'personal', to: 'review', default: true }],
+    ui: {
+      widgets: { firstName: { component: 'Text', label: 'First name' } },
+    },
+  });
+
+  it('keeps the review step active when freeze flag is enabled', async () => {
+    process.env.NEXT_PUBLIC_FLAGS = 'nav.reviewFreeze=true';
+    const schema = buildSchemaWithConfirmation();
+    const onSubmit = jest.fn();
+
+    render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: /review/i })).toBeInTheDocument());
+
+    const reviewNext = await screen.findByRole('button', { name: /next/i });
+    fireEvent.click(reviewNext);
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: /review/i })).toBeInTheDocument());
+    expect(screen.queryByRole('heading', { name: /confirmation/i })).not.toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('bounces once to the first invalid step when submitting from review', async () => {
+    process.env.NEXT_PUBLIC_FLAGS = 'nav.reviewFreeze=true';
+    const schema = buildSchemaWithValidation();
+    const onSubmit = jest.fn();
+
+    render(<FormRenderer schema={schema} onSubmit={onSubmit} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: /review/i })).toBeInTheDocument());
+
+    const submitButton = await screen.findByRole('button', { name: /submit/i });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: /personal/i })).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getAllByRole('alert').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
**What**
- Gate the review-step freeze, terminal, and full-form validation policy behind `nav.reviewFreeze` with jump-to-invalid defaults
- Extend feature flag resolution to support enum navigation modes and surface schema navigation metadata to the renderer
- Add integration coverage ensuring Review stays put with the freeze flag and invalid submissions bounce to the first failing step

**Why**
- Review must not auto-advance once reached, and invalid submissions should drive users back to the appropriate step per navigation guardrails

**Changes**
- Updated feature flag typing/resolution to include `nav.reviewFreeze` and string-based `nav.jumpToFirstInvalidOn`
- Augmented `FormRenderer` navigation flow to freeze Review, respect jump-to-invalid policy, and avoid redundant transitions
- Added navigation config typings/validation plus new integration tests for the review freeze behavior
- Logged tracker progress for P3-NAV-03

**Flags**
- `nav.reviewFreeze` (default: false)
- `nav.jumpToFirstInvalidOn` (default: `submit`)

**Tests**
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `CI=1 FORCE_COLOR=0 npm run size`

**Docs**
- `docs/form-builder/PHASE-3-Tracker.v2.md`

**Risks**
- Potential navigation regressions if new policy incorrectly identifies review steps
- Broader flag parsing changes could affect existing flag overrides

------
https://chatgpt.com/codex/tasks/task_e_68d4fe068b38832a9950033e69754e44