### PR TITLE
[P3-NAV-08] Add analytics loop detection

### DIFF
--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -13,7 +13,7 @@
 | **P3-NAV-05**| Schema linter rules (CI blocking)                   | P0  | `codex/p3v2-nav-05-linter`    | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Linter enforces dup IDs, defaults, unknown targets, cycles; warns on missing terminal. |
 | **P3-NAV-06**| Unit tests (resolver)                               | P0  | `codex/p3v2-nav-06-tests`     | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Guard precedence + terminal null coverage verified. |
 | **P3-NAV-07**| Integration & E2E tests                             | P0  | `codex/p3v2-nav-07-e2e`       | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | Playwright keyboard flow holds Review step & verifies tab order. |
-| **P3-NAV-08**| Analytics loop detector (P1)                        | P1  | `codex/p3v2-nav-08-analytics` |             | TODO         |                                    | optional, can ship later |
+| **P3-NAV-08**| Analytics loop detector (P1)                        | P1  | `codex/p3-nav-08`             | _pending_   | In Review   | ✅ fmt/lint/type/test/build/size   | nav loop detection emits analytics event on rapid 2-3 step oscillations. |
 | P3-03        | Review step (summary-only)                          | P0  |                                |             | BLOCKED      |                                    | **Unblock after P3-NAV** |
 | P3-04        | Layout V1 (grid wrapper, flagged + fallback)        | P0  |                                |             | TODO         |                                    |       |
 | P3-05        | MultiSelect widget                                  | P0  |                                |             | TODO         |                                    |       |

--- a/packages/form-engine/src/hooks/useFormAnalytics.ts
+++ b/packages/form-engine/src/hooks/useFormAnalytics.ts
@@ -71,17 +71,9 @@ export function useFormAnalytics(
     };
   }, [formId, schemaVersion, serializedConfig]);
 
-  const trackStepView = useCallback(
-    (stepId: string) => {
-      analyticsRef.current?.trackEvent(
-        'step_viewed',
-        { formId, schemaVersion, stepId },
-        'navigation',
-        { formId, schemaVersion, stepId, sensitive: false },
-      );
-    },
-    [formId, schemaVersion],
-  );
+  const trackStepView = useCallback((stepId: string) => {
+    analyticsRef.current?.trackStepView(stepId);
+  }, []);
 
   const trackFieldInteraction = useCallback(
     (fieldName: string, value: unknown, eventType: 'focus' | 'blur' | 'change') => {


### PR DESCRIPTION
## What changed
- added loop detection to `FormAnalytics` that monitors recent step views and emits a `nav_loop_detected` event when users oscillate between two or three steps within ~2 seconds
- exposed the new analytics helper through `useFormAnalytics` so consumers automatically benefit from loop detection when they track step views
- expanded unit coverage to verify two-step and three-step oscillations trigger the new event and updated the Phase-3 tracker entry

## Why
- supports P3-NAV-08 by surfacing analytics insight when navigation loops occur, enabling monitoring before releasing review flows

## Risks
- low: detection operates within existing analytics sampling and only inspects step identifiers already emitted

## Flags
- no new feature flags; detection is part of existing analytics instrumentation and respects current flag defaults

## Tests
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `CI=1 npm run size`

## Docs & Links
- Updated `docs/form-builder/PHASE-3-Tracker.v2.md`
- Plan: `docs/form-builder/PHASE-3-PLAN.v2.md`
- Tracker: `docs/form-builder/PHASE-3-Tracker.v2.md`


------
https://chatgpt.com/codex/tasks/task_e_68d583b8a784832aae0d29d655b034b7