### PR TITLE
feat(layout): grid renderer scaffold (P3-04A)

### DIFF
--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -35,7 +35,7 @@
 
 | ID | Title | Branch | Status | PR | Notes |
 |---|---|---|---|---|---|
-| P3-04A | Grid schema types & guardrails | codex-form-builder-layout-v1 | todo |  | Add TS types; clamp & soft warnings |
+| P3-04A | GridRenderer scaffold (flag-gated) | codex-form-builder-layout-v1 | in-progress |  | Feature flag plumbing, renderer switch |
 | P3-04B | GridRenderer shell (flag-gated) | codex-form-builder-layout-v1 | todo |  | Select via flag+schema |
 | P3-04C | Field placement & fallbacks | codex-form-builder-layout-v1 | todo |  | Place fields; append unplaced |
 | P3-04D | Responsive breakpoints | codex-form-builder-layout-v1 | todo |  | CSS vars; md→sm collapse |

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '\\./validation/worker-client$':
       '<rootDir>/packages/form-engine/tests/__mocks__/worker-client.ts',
   },
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   transform: {
     '^.+\\.[tj]sx?$': [
       'ts-jest',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 require('@testing-library/jest-dom');
 
 global.matchMedia =
@@ -14,3 +15,21 @@ global.matchMedia =
       dispatchEvent: jest.fn(),
     };
   };
+
+const { TextEncoder, TextDecoder } = require('util');
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
+
+if (typeof global.ResizeObserver === 'undefined') {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/packages/form-engine/src/renderer/FormRenderer.tsx
+++ b/packages/form-engine/src/renderer/FormRenderer.tsx
@@ -22,6 +22,7 @@ import { formatValue as formatReviewValue } from '../utils/review-format';
 
 import { ErrorSummary } from './ErrorSummary';
 import { StepProgress } from './StepProgress';
+import { GridRenderer } from './layout/GridRenderer';
 import {
   flattenFieldErrors,
   getStepFieldNames,
@@ -1367,64 +1368,77 @@ const FormRendererInner: React.FC<FormRendererProps> = ({
               ) : null}
 
               <div className="space-y-4">
-                {Object.entries(stepProperties).map(([fieldName]) => {
-                  if (!visibleFields.includes(fieldName)) return null;
+                {activeLayout === 'grid' ? (
+                  <GridRenderer
+                    schema={schema}
+                    currentStepSchema={currentStepSchema}
+                    stepProperties={stepProperties}
+                    visibleFields={visibleFields}
+                    mode={mode}
+                    isSessionExpired={isSessionExpired}
+                  />
+                ) : (
+                  Object.entries(stepProperties).map(([fieldName]) => {
+                    if (!visibleFields.includes(fieldName)) return null;
 
-                  const uiConfig = (schema.ui?.widgets ?? {})[fieldName];
-                  if (!uiConfig) {
-                    console.warn(`No widget configuration found for field: ${fieldName}`);
-                    return null;
-                  }
-
-                  const {
-                    component,
-                    label,
-                    placeholder,
-                    helpText,
-                    description,
-                    className: widgetClassName,
-                    options,
-                    disabled,
-                    readOnly,
-                    ...componentProps
-                  } = uiConfig;
-
-                  const widget: WidgetType = component ?? 'Text';
-                  const fieldError =
-                    methods.formState.errors?.[fieldName as keyof typeof methods.formState.errors];
-                  const errorMessage = (() => {
-                    if (fieldError && typeof fieldError === 'object' && 'message' in fieldError) {
-                      return (fieldError as { message?: string }).message ?? 'Invalid value';
+                    const uiConfig = (schema.ui?.widgets ?? {})[fieldName];
+                    if (!uiConfig) {
+                      console.warn(`No widget configuration found for field: ${fieldName}`);
+                      return null;
                     }
-                    if (typeof fieldError === 'string') return fieldError;
-                    return undefined;
-                  })();
 
-                  const isRequired = Array.isArray(currentStepSchema.required)
-                    ? currentStepSchema.required.includes(fieldName)
-                    : false;
+                    const {
+                      component,
+                      label,
+                      placeholder,
+                      helpText,
+                      description,
+                      className: widgetClassName,
+                      options,
+                      disabled,
+                      readOnly,
+                      ...componentProps
+                    } = uiConfig;
 
-                  return (
-                    <FieldFactory
-                      key={fieldName}
-                      name={fieldName}
-                      label={label ?? fieldName}
-                      widget={widget}
-                      placeholder={placeholder}
-                      description={description}
-                      helpText={helpText}
-                      className={widgetClassName as string | undefined}
-                      disabled={mode === 'view' || disabled || isSessionExpired}
-                      readOnly={readOnly}
-                      required={isRequired}
-                      control={methods.control}
-                      rules={undefined}
-                      options={options}
-                      componentProps={componentProps as Record<string, unknown>}
-                      error={errorMessage}
-                    />
-                  );
-                })}
+                    const widget: WidgetType = component ?? 'Text';
+                    const fieldError =
+                      methods.formState.errors?.[
+                        fieldName as keyof typeof methods.formState.errors
+                      ];
+                    const errorMessage = (() => {
+                      if (fieldError && typeof fieldError === 'object' && 'message' in fieldError) {
+                        return (fieldError as { message?: string }).message ?? 'Invalid value';
+                      }
+                      if (typeof fieldError === 'string') return fieldError;
+                      return undefined;
+                    })();
+
+                    const isRequired = Array.isArray(currentStepSchema.required)
+                      ? currentStepSchema.required.includes(fieldName)
+                      : false;
+
+                    return (
+                      <FieldFactory
+                        key={fieldName}
+                        name={fieldName}
+                        label={label ?? fieldName}
+                        widget={widget}
+                        placeholder={placeholder}
+                        description={description}
+                        helpText={helpText}
+                        className={widgetClassName as string | undefined}
+                        disabled={mode === 'view' || disabled || isSessionExpired}
+                        readOnly={readOnly}
+                        required={isRequired}
+                        control={methods.control}
+                        rules={undefined}
+                        options={options}
+                        componentProps={componentProps as Record<string, unknown>}
+                        error={errorMessage}
+                      />
+                    );
+                  })
+                )}
               </div>
 
               <ErrorSummary errors={methods.formState.errors} onFocusField={focusField} />

--- a/packages/form-engine/src/renderer/layout/GridRenderer.tsx
+++ b/packages/form-engine/src/renderer/layout/GridRenderer.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import type { JSONSchema, UnifiedFormSchema } from '../../types';
+
+export interface GridRendererProps {
+  schema: UnifiedFormSchema;
+  currentStepSchema: JSONSchema;
+  stepProperties: Record<string, JSONSchema>;
+  visibleFields: string[];
+  mode: 'create' | 'edit' | 'view';
+  isSessionExpired: boolean;
+}
+
+export const GridRenderer: React.FC<GridRendererProps> = () => {
+  return <div data-testid="grid-renderer-placeholder" />;
+};

--- a/packages/form-engine/tests/unit/FormRenderer.test.tsx
+++ b/packages/form-engine/tests/unit/FormRenderer.test.tsx
@@ -1113,4 +1113,16 @@ describe('FormRenderer', () => {
     const form = container.querySelector('form');
     expect(form).toHaveAttribute('data-layout', 'single-column');
   });
+
+  it('renders the grid layout container when the flag and schema opt in', () => {
+    const schema = buildSchema();
+    schema.ui.layout = { type: 'grid' };
+    process.env.NEXT_PUBLIC_FLAGS = 'gridLayout=true';
+
+    const { container } = render(<FormRenderer schema={schema} onSubmit={jest.fn()} />);
+
+    const form = container.querySelector('form');
+    expect(form).toHaveAttribute('data-layout', 'grid');
+    expect(screen.getByTestId('grid-renderer-placeholder')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- introduce a GridRenderer placeholder and switch FormRenderer to select it when the grid flag and schema opt in
- add jest polyfills and ignore dist artifacts so the suite runs in jsdom
- mark tracker row P3-04A as in progress for the scaffold task

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test *(fails: integration/formrenderer.review.submit.test.tsx cannot find inline alert in baseline setup)*
- npm run build
- CI=1 npm run size

------
https://chatgpt.com/codex/tasks/task_e_68da81235374832a8c696ff4822938d5