### PR TITLE
[P3-04] Responsive breakpoints

### DIFF
--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -38,7 +38,7 @@
 | P3-04A | GridRenderer scaffold (flag-gated) | codex-form-builder-layout-v1 | in-progress |  | Feature flag plumbing, renderer switch |
 | P3-04B | Grid responsive + schema contract | codex-form-builder-layout-v1 | done |  | Responsive columns, gutter/rowGap vars, schema overrides |
 | P3-04C | Field placement & fallbacks | codex-form-builder-layout-v1 | done | pending | Grid renderer places fields per layout, appends fallback row, adds tests (PR link pending) |
-| P3-04D | Responsive breakpoints | codex-form-builder-layout-v1 | todo |  | CSS vars; md→sm collapse |
+| P3-04D | Responsive breakpoints | codex-form-builder-layout-v1 | review | link | CSS vars for breakpoints + auto single-column collapse |
 | P3-04E | Sections (titles/landmarks) | codex-form-builder-layout-v1 | todo |  | a11y semantics |
 | P3-04F | Per‑widget layout hints | codex-form-builder-layout-v1 | todo |  | colSpan/align/size precedence |
 | P3-04G | Error rendering stability | codex-form-builder-layout-v1 | todo |  | No grid jump on errors |

--- a/packages/form-engine/src/renderer/layout/__tests__/__snapshots__/GridRenderer.spec.tsx.snap
+++ b/packages/form-engine/src/renderer/layout/__tests__/__snapshots__/GridRenderer.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`GridRenderer renders configured fields respecting spans and explicit or
       <div
         class="grid"
         data-grid-row="true"
-        style="display: grid; grid-template-columns: repeat(var(--cols), minmax(0, 1fr)); column-gap: var(--gutter); row-gap: var(--rowgap); --cols: 4; --gutter: 16px; --rowgap: 16px;"
+        style="display: grid; grid-template-columns: repeat(var(--cols), minmax(0, 1fr)); column-gap: var(--gutter); row-gap: var(--rowgap); --cols: 4; --gutter: 16px; --rowgap: 16px; --cols-base: 4; --cols-sm: 4; --cols-md: 4; --cols-lg: 4; --cols-xl: 4;"
       >
         <div
           data-grid-field="email"

--- a/packages/form-engine/src/renderer/layout/__tests__/responsive.spec.ts
+++ b/packages/form-engine/src/renderer/layout/__tests__/responsive.spec.ts
@@ -1,0 +1,32 @@
+import { computeGridStyles, inferBreakpointFromWidth } from '../responsive';
+import type { LayoutConfig } from '../../../types';
+
+describe('responsive helpers', () => {
+  const layout: LayoutConfig = {
+    type: 'grid',
+    columns: { md: 6, lg: 8 },
+    gutter: { base: 12, md: 24 },
+    rowGap: { base: 16 },
+  };
+
+  it('computes CSS variables for each breakpoint and collapses to a single column by default on base', () => {
+    const baseStyles = computeGridStyles(layout, 'base');
+
+    expect(baseStyles.columns).toBe(1);
+    expect(baseStyles.style['--cols']).toBe('1');
+    expect(baseStyles.style['--cols-base']).toBe('1');
+    expect(baseStyles.style['--cols-md']).toBe('6');
+    expect(baseStyles.style['--cols-lg']).toBe('8');
+  });
+
+  it('resolves breakpoint widths using overrides', () => {
+    expect(inferBreakpointFromWidth(1280)).toBe('xl');
+    expect(inferBreakpointFromWidth(900)).toBe('md');
+    expect(inferBreakpointFromWidth(500)).toBe('base');
+
+    const overrides = { sm: 500, md: 700 };
+    expect(inferBreakpointFromWidth(750, overrides)).toBe('md');
+    expect(inferBreakpointFromWidth(520, overrides)).toBe('sm');
+    expect(inferBreakpointFromWidth(400, overrides)).toBe('base');
+  });
+});


### PR DESCRIPTION
## Summary
- add responsive column defaults that collapse to a single column on base breakpoints while exposing per-breakpoint CSS variables
- extend GridRenderer viewport handling to update CSS custom properties on resize and cover with unit tests
- document tracker progress for P3-04D

## Flags & rollout
- `gridLayout` flag remains **OFF** by default; enable locally with `NEXT_PUBLIC_FLAGS=gridLayout=1`

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- CI=1 npm run size

## Risk & Rollback
- Low risk: feature remains flag-gated and falls back to single-column renderer when disabled. Roll back by reverting this commit if issues arise.

Labels: phase-3, layout-engine

------
https://chatgpt.com/codex/tasks/task_e_68db83b3f4a4832aad6e19fb787f401a