### PR TITLE
feat(layout): ensure section descriptions announce (step P3-04E)

### DIFF
--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -39,7 +39,7 @@
 | P3-04B | Grid responsive + schema contract | codex-form-builder-layout-v1 | done |  | Responsive columns, gutter/rowGap vars, schema overrides |
 | P3-04C | Field placement & fallbacks | codex-form-builder-layout-v1 | done | pending | Grid renderer places fields per layout, appends fallback row, adds tests (PR link pending) |
 | P3-04D | Responsive breakpoints | codex-form-builder-layout-v1 | review | link | CSS vars for breakpoints + auto single-column collapse |
-| P3-04E | Sections (titles/landmarks) | codex-form-builder-phase-3-layout-engine | review | pending | Heading levels clamp + aria landmarks |
+| P3-04E | Sections (titles/landmarks) | codex-form-builder-phase-3-layout-engine | review | pending | Heading levels clamp + aria landmarks; section descriptions announced via aria-describedby |
 | P3-04F | Per‑widget layout hints | codex-form-builder-phase-3-layout-engine | review | pending | Widget layout hints backfill colSpan/align/size defaults |
 | P3-04G | Error rendering stability | codex-form-builder-phase-3-layout-engine | review | pending | No grid jump on errors |
 | P3-04H | Demo schema: opt‑in layout | codex-form-builder-layout-v1 | todo |  | Minimal 2‑col example |

--- a/packages/form-engine/src/renderer/layout/GridRenderer.tsx
+++ b/packages/form-engine/src/renderer/layout/GridRenderer.tsx
@@ -309,7 +309,7 @@ export const GridRenderer: React.FC<GridRendererProps> = ({
         }
       } else {
         ariaAttributes['aria-label'] = fallbackAriaLabel;
-        if (descriptionId && fallbackAriaLabel !== descriptionText) {
+        if (descriptionId) {
           ariaAttributes['aria-describedby'] = descriptionId;
         }
       }

--- a/packages/form-engine/src/renderer/layout/__tests__/GridRenderer.spec.tsx
+++ b/packages/form-engine/src/renderer/layout/__tests__/GridRenderer.spec.tsx
@@ -194,7 +194,14 @@ describe('GridRenderer', () => {
     expect(section).not.toBeNull();
     expect(section.getAttribute('role')).toBe('region');
     expect(section.getAttribute('aria-label')).toBe('Additional context');
-    expect(section.getAttribute('aria-describedby')).toBeNull();
+
+    const description = section.querySelector('[data-grid-section-description]') as
+      | HTMLElement
+      | null;
+    expect(description).not.toBeNull();
+    if (description) {
+      expect(section.getAttribute('aria-describedby')).toBe(description.id);
+    }
 
     const row = section.querySelector('[data-grid-row]');
     expect(row).not.toBeNull();


### PR DESCRIPTION
## Summary
- ensure grid layout sections always expose descriptions through `aria-describedby` so assistive tech hears the context
- extend GridRenderer coverage for fallback-labeled sections
- update the Phase 3 tracker entry for P3-04E

## Testing
- `npm run test -- GridRenderer`
- `npx prettier --check packages/form-engine/src/renderer/layout/GridRenderer.tsx packages/form-engine/src/renderer/layout/__tests__/GridRenderer.spec.tsx docs/form-builder/PHASE-3-Tracker.v2.md`

## Checklist
- [x] Implemented requirements from docs/form-builder/PHASE-3-PLAN.v2.md (P3-04E)
- [x] Added/updated tests (Jest/RTL)
- [x] Code formatted with Prettier
- [ ] CI passing (lint + typecheck + tests)


------
https://chatgpt.com/codex/tasks/task_e_68dbbaeaa458832a9dd1df958e9ab1b6