### PR TITLE
feat(layout): demo schema grid opt-in (step P3-04H)

### DIFF
--- a/apps/form-builder-demo/README.md
+++ b/apps/form-builder-demo/README.md
@@ -2,3 +2,15 @@
 
 This directory is reserved for the interactive demo that will consume the form engine package.
 Future steps in the implementation plan will scaffold the actual application code.
+
+## Previewing the grid layout
+
+The demo schema now includes a flag-gated grid layout configuration. The feature remains disabled by default.
+To preview it locally, start the dev server with the grid flag enabled:
+
+```bash
+export NEXT_PUBLIC_FLAGS="gridLayout=1"
+npm run dev
+```
+
+Unset or omit the flag to return to the single-column renderer.

--- a/docs/form-builder/PHASE-3-Tracker.v2.md
+++ b/docs/form-builder/PHASE-3-Tracker.v2.md
@@ -42,7 +42,7 @@
 | P3-04E | Sections (titles/landmarks) | codex-form-builder-phase-3-layout-engine | review | pending | Heading levels clamp + aria landmarks; section descriptions announced via aria-describedby |
 | P3-04F | Per‑widget layout hints | codex-form-builder-phase-3-layout-engine | review | pending | Widget layout hints backfill colSpan/align/size defaults |
 | P3-04G | Error rendering stability | codex-form-builder-phase-3-layout-engine | review | pending | No grid jump on errors |
-| P3-04H | Demo schema: opt‑in layout | codex-form-builder-layout-v1 | todo |  | Minimal 2‑col example |
+| P3-04H | Demo schema: opt‑in layout | codex-form-builder-phase-3-layout-engine | review | pending | Minimal 2‑col layout configured in demo schema; flag off by default |
 | P3-04I | Docs & examples | codex-form-builder-layout-v1 | todo |  | FEATURES.md/README updates |
 
 ---

--- a/src/demo/DemoFormSchema.ts
+++ b/src/demo/DemoFormSchema.ts
@@ -356,8 +356,160 @@ export const demoFormSchema: UnifiedFormSchema = {
   ],
   ui: {
     layout: {
-      type: 'single-column',
-      gutter: 24,
+      type: 'grid',
+      columns: { base: 4, md: 8 },
+      gutter: { base: 16, md: 24 },
+      rowGap: { base: 20, md: 24 },
+      sections: [
+        {
+          id: 'personal-details',
+          title: 'Contact details',
+          rows: [
+            {
+              fields: [
+                { name: 'firstName', colSpan: { base: 4, md: 4 } },
+                { name: 'lastName', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'email', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'phone', colSpan: { base: 4, md: 4 } },
+                { name: 'postcode', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'dateOfBirth', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'employment-status',
+          title: 'Employment information',
+          rows: [
+            {
+              fields: [
+                { name: 'currentStatus', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'employer', colSpan: { base: 4, md: 4 } },
+                { name: 'position', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'salary', colSpan: { base: 4, md: 4 } },
+                { name: 'startDate', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'experience-highlights',
+          title: 'Experience and highlights',
+          rows: [
+            {
+              fields: [
+                { name: 'yearsExperience', colSpan: { base: 4, md: 4 } },
+                { name: 'keySkills', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'highlightProjects', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'education',
+          title: 'Education',
+          rows: [
+            {
+              fields: [
+                { name: 'highestDegree', colSpan: { base: 4, md: 4 } },
+                { name: 'institution', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'graduationYear', colSpan: { base: 4, md: 4 } },
+                { name: 'gpa', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'role-preferences',
+          title: 'Role preferences',
+          rows: [
+            {
+              fields: [
+                { name: 'jobType', colSpan: { base: 4, md: 4 } },
+                { name: 'remotePreference', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'salaryExpectation', colSpan: { base: 4, md: 4 } },
+                { name: 'availabilityDate', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'relocate', colSpan: { base: 4, md: 4 } },
+                { name: 'preferredLocation', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'references', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'legal',
+          title: 'Declarations',
+          rows: [
+            {
+              fields: [
+                { name: 'workAuthorization', colSpan: { base: 4, md: 4 } },
+                { name: 'requiresSponsorship', colSpan: { base: 4, md: 4 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'backgroundCheckConsent', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'review',
+          title: 'Review and submit',
+          rows: [
+            {
+              fields: [
+                { name: 'confirmAccuracy', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+            {
+              fields: [
+                { name: 'coverLetter', colSpan: { base: 4, md: 8 } },
+              ],
+            },
+          ],
+        },
+      ],
     },
     theme: {
       brandColor: '#1d4ed8',


### PR DESCRIPTION
## Summary
- configure the demo schema with grid sections and responsive column spans for each step
- keep the grid feature flag off by default while documenting how to enable the layout preview locally
- update the tracker entry for P3-04H to reflect the new PR

## Checklist
- [x] Add minimal grid layout to demo schema with two-column rows and single-column review
- [x] Keep flag defaulted off and note how to enable it locally
- [x] Update Phase 3 tracker status for P3-04H

## Testing
- npm run format
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dbbe9d3e90832aa93aae674dd5b3e3