### PR TITLE
feat(demo+docs): grid layout follow-up polish

### DIFF
--- a/docs/form-builder/step-11-demo-form.md
+++ b/docs/form-builder/step-11-demo-form.md
@@ -292,7 +292,89 @@ export const demoFormSchema: UnifiedFormSchema = {
 };
 ```
 
-### 11.3 Create Main Demo Form Component
+### 11.3 Configure responsive grid layout
+
+The demo schema now opts into the Phase 3 grid renderer so that each step highlights responsive columns, contextual sections, and breakpoint-aware spans.
+
+```typescript
+// src/demo/DemoFormSchema.ts (excerpt)
+
+ui: {
+  layout: {
+    type: 'grid',
+    gutter: 24,
+    columns: 6,
+    breakpoints: {
+      base: 1,
+      sm: 2,
+      md: 6,
+      lg: 12,
+      xl: 12,
+      '2xl': 12,
+    },
+    sections: [
+      {
+        id: 'personal-details',
+        title: 'Contact details',
+        rows: [
+          {
+            id: 'personal-names',
+            fields: ['firstName', 'lastName'],
+            colSpan: {
+              firstName: { base: 1, sm: 1, md: 3, lg: 6 },
+              lastName: { base: 1, sm: 1, md: 3, lg: 6 },
+            },
+          },
+          {
+            id: 'personal-contact',
+            fields: ['email', 'phone'],
+            colSpan: {
+              email: { base: 1, sm: 2, md: 4, lg: 8 },
+              phone: { base: 1, sm: 2, md: 2, lg: 4 },
+            },
+          },
+        ],
+      },
+      {
+        id: 'review-confirmation',
+        title: 'Final confirmation',
+        rows: [
+          {
+            id: 'review-consent',
+            fields: ['confirmAccuracy'],
+            colSpan: {
+              confirmAccuracy: { base: 1, sm: 2, md: 3, lg: 4 },
+            },
+          },
+          {
+            id: 'review-cover-letter',
+            fields: ['coverLetter'],
+            colSpan: {
+              coverLetter: { base: 1, sm: 2, md: 6, lg: 12 },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  widgets: {
+    // … existing widget configuration
+  },
+}
+```
+
+Sections map 1:1 with form steps so content is only rendered when relevant. Rows define field order, while `colSpan` values illustrate how the grid expands from single-column on mobile to multi-column layouts on larger breakpoints. Fields hidden via conditional rules collapse automatically, ensuring no empty grid cells remain.
+
+To verify locally, run the demo with layout flags enabled:
+
+```bash
+export NEXT_PUBLIC_FLAGS="gridLayout=1,nav.dedupeToken=1,nav.reviewFreeze=1,nav.jumpToFirstInvalidOn=submit"
+npm run dev
+```
+
+Submit an invalid form to see the alert banner, tick the confirmation checkbox to unblock submission, and confirm the review step renders formatted values instead of raw JSON.
+
+### 11.4 Create Main Demo Form Component
 ```typescript
 // src/demo/DemoForm.tsx
 

--- a/src/demo/DemoFormSchema.ts
+++ b/src/demo/DemoFormSchema.ts
@@ -356,8 +356,200 @@ export const demoFormSchema: UnifiedFormSchema = {
   ],
   ui: {
     layout: {
-      type: 'single-column',
+      type: 'grid',
       gutter: 24,
+      columns: 6,
+      breakpoints: {
+        base: 1,
+        sm: 2,
+        md: 6,
+        lg: 12,
+        xl: 12,
+        '2xl': 12,
+      },
+      sections: [
+        {
+          id: 'personal-details',
+          title: 'Contact details',
+          description: 'How we can reach and verify you.',
+          rows: [
+            {
+              id: 'personal-names',
+              fields: ['firstName', 'lastName'],
+              colSpan: {
+                firstName: { base: 1, sm: 1, md: 3, lg: 6 },
+                lastName: { base: 1, sm: 1, md: 3, lg: 6 },
+              },
+            },
+            {
+              id: 'personal-contact',
+              fields: ['email', 'phone'],
+              colSpan: {
+                email: { base: 1, sm: 2, md: 4, lg: 8 },
+                phone: { base: 1, sm: 2, md: 2, lg: 4 },
+              },
+            },
+            {
+              id: 'personal-identity',
+              fields: ['postcode', 'dateOfBirth'],
+              colSpan: {
+                postcode: { base: 1, sm: 1, md: 3, lg: 6 },
+                dateOfBirth: { base: 1, sm: 1, md: 3, lg: 6 },
+              },
+            },
+          ],
+        },
+        {
+          id: 'employment-status',
+          title: 'Employment details',
+          description: 'Tell us about your current role.',
+          rows: [
+            {
+              id: 'employment-current-status',
+              fields: ['currentStatus'],
+              colSpan: {
+                currentStatus: { base: 1, sm: 2, md: 6, lg: 12 },
+              },
+            },
+            {
+              id: 'employment-role',
+              fields: ['employer', 'position'],
+              colSpan: {
+                employer: { base: 1, sm: 2, md: 3, lg: 6 },
+                position: { base: 1, sm: 2, md: 3, lg: 6 },
+              },
+            },
+            {
+              id: 'employment-compensation',
+              fields: ['salary', 'startDate'],
+              colSpan: {
+                salary: { base: 1, sm: 2, md: 3, lg: 6 },
+                startDate: { base: 1, sm: 2, md: 3, lg: 6 },
+              },
+            },
+          ],
+        },
+        {
+          id: 'experience-highlights',
+          title: 'Experience highlights',
+          description: 'Summarise your background and projects.',
+          rows: [
+            {
+              id: 'experience-summary',
+              fields: ['yearsExperience', 'keySkills'],
+              colSpan: {
+                yearsExperience: { base: 1, sm: 1, md: 2, lg: 4 },
+                keySkills: { base: 1, sm: 2, md: 4, lg: 8 },
+              },
+            },
+            {
+              id: 'experience-projects',
+              fields: ['highlightProjects'],
+              colSpan: {
+                highlightProjects: { base: 1, sm: 2, md: 6, lg: 12 },
+              },
+            },
+          ],
+        },
+        {
+          id: 'education-background',
+          title: 'Education',
+          description: 'Academic record and achievements.',
+          rows: [
+            {
+              id: 'education-degree',
+              fields: ['highestDegree'],
+              colSpan: {
+                highestDegree: { base: 1, sm: 2, md: 6, lg: 12 },
+              },
+            },
+            {
+              id: 'education-details',
+              fields: ['institution', 'graduationYear', 'gpa'],
+              colSpan: {
+                institution: { base: 1, sm: 2, md: 3, lg: 6 },
+                graduationYear: { base: 1, sm: 2, md: 2, lg: 3 },
+                gpa: { base: 1, sm: 2, md: 1, lg: 3 },
+              },
+            },
+          ],
+        },
+        {
+          id: 'preferences-fit',
+          title: 'Role preferences',
+          description: 'What you are looking for in your next role.',
+          rows: [
+            {
+              id: 'preferences-basics',
+              fields: ['jobType', 'remotePreference'],
+              colSpan: {
+                jobType: { base: 1, sm: 1, md: 3, lg: 6 },
+                remotePreference: { base: 1, sm: 1, md: 3, lg: 6 },
+              },
+            },
+            {
+              id: 'preferences-compensation',
+              fields: ['salaryExpectation', 'availabilityDate', 'relocate'],
+              colSpan: {
+                salaryExpectation: { base: 1, sm: 2, md: 3, lg: 5 },
+                availabilityDate: { base: 1, sm: 2, md: 2, lg: 4 },
+                relocate: { base: 1, sm: 2, md: 1, lg: 3 },
+              },
+            },
+            {
+              id: 'preferences-location',
+              fields: ['preferredLocation'],
+              colSpan: {
+                preferredLocation: { base: 1, sm: 2, md: 6, lg: 12 },
+              },
+            },
+            {
+              id: 'preferences-references',
+              fields: ['references'],
+              colSpan: {
+                references: { base: 1, sm: 2, md: 6, lg: 12 },
+              },
+            },
+          ],
+        },
+        {
+          id: 'legal-confirmations',
+          title: 'Declarations',
+          description: 'Confirm your eligibility to work with us.',
+          rows: [
+            {
+              id: 'legal-review',
+              fields: ['workAuthorization', 'requiresSponsorship', 'backgroundCheckConsent'],
+              colSpan: {
+                workAuthorization: { base: 1, sm: 2, md: 2, lg: 4 },
+                requiresSponsorship: { base: 1, sm: 2, md: 2, lg: 4 },
+                backgroundCheckConsent: { base: 1, sm: 2, md: 2, lg: 4 },
+              },
+            },
+          ],
+        },
+        {
+          id: 'review-confirmation',
+          title: 'Final confirmation',
+          description: 'Agree to submit and optionally attach a cover letter.',
+          rows: [
+            {
+              id: 'review-consent',
+              fields: ['confirmAccuracy'],
+              colSpan: {
+                confirmAccuracy: { base: 1, sm: 2, md: 3, lg: 4 },
+              },
+            },
+            {
+              id: 'review-cover-letter',
+              fields: ['coverLetter'],
+              colSpan: {
+                coverLetter: { base: 1, sm: 2, md: 6, lg: 12 },
+              },
+            },
+          ],
+        },
+      ],
     },
     theme: {
       brandColor: '#1d4ed8',


### PR DESCRIPTION
## Summary
- enable the demo schema to opt into the grid renderer with responsive sections and column spans across every step
- document how to configure the grid layout and which flags to toggle for the local smoke check

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- CI=1 npm run size
- NEXT_PUBLIC_FLAGS="gridLayout=1,nav.dedupeToken=1,nav.reviewFreeze=1,nav.jumpToFirstInvalidOn=submit" npm run dev (smoke via curl)

## Checklist
- [x] Demo schema uses `ui.layout.type = 'grid'` with columns/gutter/sections.
- [x] Docs updated with usage + examples.
- [x] `npm run build` passed locally.
- [x] `CI=1 npm run size` within budget.
- [x] Manual smoke (flags ON) passed (started dev server and hit /demo; noted existing jsonpath SSR warning but request returns 200 and grid markup renders).


------
https://chatgpt.com/codex/tasks/task_e_68e50cd77584832ab18c529ffb68c8b5